### PR TITLE
Close #3 and #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@
 
 # dependencies
 /node_modules
+
+# local testing
+src/components
+generate-react-cli.json
+
+# ide
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -343,6 +343,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash-es": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "esm": "^3.2.25",
     "fs-extra": "^8.1.0",
     "inquirer": "^7.0.0",
+    "lodash-es": "^4.17.15",
     "replace": "^1.1.1"
   },
   "files": [

--- a/src/services/templateService.js
+++ b/src/services/templateService.js
@@ -1,5 +1,6 @@
 import { existsSync, outputFileSync } from 'fs-extra';
 import chalk from 'chalk';
+import { camelCase } from 'lodash-es';
 import replace from 'replace';
 
 export function generateComponentTemplates(componentTemplates) {
@@ -13,12 +14,20 @@ export function generateComponentTemplates(componentTemplates) {
       try {
         outputFileSync(componentPath, template);
 
-        replace({
+        const replaceDefaultOptions = {
           regex: 'TemplateName',
           replacement: componentName,
           paths: [componentPath],
           recursive: false,
           silent: true,
+        };
+
+        replace(replaceDefaultOptions);
+
+        replace({
+          ...replaceDefaultOptions,
+          regex: 'templateName',
+          replacement: camelCase(componentName),
         });
 
         console.log(chalk.green(`${templateType} was created successfully at ${componentPath}`));

--- a/src/templates/components/componentJsTemplate.js
+++ b/src/templates/components/componentJsTemplate.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styles from './TemplateName.module.css';
 
 const TemplateName = () => (
-  <div className={styles.TemplateName}>
+  <div className={styles.TemplateName} data-testid="TemplateName">
     TemplateName Component
   </div>
 );

--- a/src/templates/components/componentTestTestingLibraryTemplate.js
+++ b/src/templates/components/componentTestTestingLibraryTemplate.js
@@ -8,8 +8,8 @@ describe('<TemplateName />', () => {
 
   test('it should mount', () => {
     const { getByText } = render(<TemplateName />);
-    const FollowBtn = getByText('TemplateName Component');
+    const templateName = getByText('TemplateName Component');
 
-    expect(FollowBtn).toBeInTheDocument();
+    expect(templateName).toBeInTheDocument();
   });
 });`;

--- a/src/templates/components/componentTestTestingLibraryTemplate.js
+++ b/src/templates/components/componentTestTestingLibraryTemplate.js
@@ -7,8 +7,8 @@ describe('<TemplateName />', () => {
   afterEach(cleanup);
 
   test('it should mount', () => {
-    const { getByText } = render(<TemplateName />);
-    const templateName = getByText('TemplateName Component');
+    const { getByTestId } = render(<TemplateName />);
+    const templateName = getByTestId('TemplateName');
 
     expect(templateName).toBeInTheDocument();
   });


### PR DESCRIPTION
Updates:
- Use camelCased component name for selecting component in `@testing-library` test file (#3)
- Use `getByTestId` vs `getByText` by default in `@testing-library` test file (#4)