### PR TITLE
@testing-library recommendations from Kent

### DIFF
--- a/src/templates/component/componentTestTestingLibraryTemplate.js
+++ b/src/templates/component/componentTestTestingLibraryTemplate.js
@@ -1,14 +1,13 @@
 module.exports = `import React from 'react';
-import { cleanup, render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import TemplateName from './TemplateName';
 
 describe('<TemplateName />', () => {
-  afterEach(cleanup);
-
   test('it should mount', () => {
-    const { getByTestId } = render(<TemplateName />);
-    const templateName = getByTestId('TemplateName');
+    render(<TemplateName />);
+    
+    const templateName = screen.getByTestId('TemplateName');
 
     expect(templateName).toBeInTheDocument();
   });


### PR DESCRIPTION
### Updates
- Don't use `cleanup` ([link](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#using-cleanup))
- Use `screen` instead of destructuring `render` ([link](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#using-cleanup))

Note: This is not a breaking change for our @britannica `renderWithApolloProvider`, `renderWithRouter`, and `renderWithRouterAndApolloProvider` test utilities.