### PR TITLE
React components must start with a upper case letter.

### DIFF
--- a/src/actions/componentActions.js
+++ b/src/actions/componentActions.js
@@ -1,4 +1,5 @@
 const chalk = require('chalk');
+const { upperFirst } = require('lodash');
 const {
   componentTemplateTypes,
   generateComponentTemplates,
@@ -29,7 +30,7 @@ function generateComponent(cmd, cliConfigFile, componentName) {
       (cmd[componentTemplateType] && cmd[componentTemplateType].toString() === 'true') ||
       componentTemplateType === componentTemplateTypes.COMPONENT
     ) {
-      const template = getComponentTemplate(cmd, cliConfigFile, componentName, componentTemplateType);
+      const template = getComponentTemplate(cmd, cliConfigFile, upperFirst(componentName), componentTemplateType);
 
       if (template) {
         componentTemplates.push(template);


### PR DESCRIPTION
Currently you can name your components all lowercase and GRC will comply and generate the component as requested, according to the best practices, custom components must start with a upper case letter.

I think this package should enforce components to start with a upper case letter, as pointed by [the React team and JSX docs](https://reactjs.org/docs/jsx-in-depth.html#user-defined-components-must-be-capitalized)  and of course [StackOverflow](https://stackoverflow.com/questions/30373343/reactjs-component-names-must-begin-with-capital-letters). 

This PR does just that, uses lodash's `upperFirst` and enforces the rule to the folder, file name and component name.

