### PR TITLE
feat: allow generation of multiple components at once

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -65,10 +65,10 @@ Otherwise you won't be able to use your "${chalk.bold(componentType)}" component
     }
 
     program
-      .command('component <name>')
+      .command('component [names...]')
       .alias('c')
 
-      .option('-p, --path <path>', 'The path where the component will get genereted in.', component.path)
+      .option('-p, --path <path>', 'The path where the component will get generated in.', component.path)
       .option('--withStyle <withStyle>', 'With corresponding stylesheet file.', component.withStyle)
       .option('--withTest <withTest>', 'With corresponding test file.', component.withTest)
       .option('--withStory <withStory>', 'With corresponding story file.', component.withStory)
@@ -79,7 +79,9 @@ Otherwise you won't be able to use your "${chalk.bold(componentType)}" component
         'default'
       )
 
-      .action((componentName, cmd) => generateComponent(cmd, cliConfigFile, componentName));
+      .action((componentNames, cmd) =>
+        componentNames.forEach((componentName) => generateComponent(cmd, cliConfigFile, componentName))
+      );
   }
 
   program.parse(args);


### PR DESCRIPTION
### Feature
Allow users to create multiple components with a single command. Options will be applied to all components.

**Example**
```js
npx generate-react-cli component ComponentA ComponentB ComponentC --withLazy=true
```

The above command will create three components, all with the `withLazy` flag set to true.