### PR TITLE
Allow user to choose uppercase or lowercase in TemplateName

### DIFF
--- a/src/actions/componentActions.js
+++ b/src/actions/componentActions.js
@@ -1,5 +1,4 @@
 const chalk = require('chalk');
-const { upperFirst } = require('lodash');
 const {
   componentTemplateTypes,
   generateComponentTemplates,

--- a/src/actions/componentActions.js
+++ b/src/actions/componentActions.js
@@ -27,7 +27,9 @@ function generateComponent(cmd, cliConfigFile, componentName) {
 
     if (
       (cmd[componentTemplateType] && cmd[componentTemplateType].toString() === 'true') ||
-      componentTemplateType === componentTemplateTypes.COMPONENT
+      componentTemplateType === componentTemplateTypes.COMPONENT ||
+      componentTemplateType === componentTemplateTypes.ACTION ||
+      componentTemplateType === componentTemplateTypes.REDUCER
     ) {
       const template = getComponentTemplate(cmd, cliConfigFile, componentName, componentTemplateType);
 

--- a/src/actions/componentActions.js
+++ b/src/actions/componentActions.js
@@ -30,7 +30,7 @@ function generateComponent(cmd, cliConfigFile, componentName) {
       (cmd[componentTemplateType] && cmd[componentTemplateType].toString() === 'true') ||
       componentTemplateType === componentTemplateTypes.COMPONENT
     ) {
-      const template = getComponentTemplate(cmd, cliConfigFile, upperFirst(componentName), componentTemplateType);
+      const template = getComponentTemplate(cmd, cliConfigFile, componentName, componentTemplateType);
 
       if (template) {
         componentTemplates.push(template);

--- a/src/services/componentTemplateService.js
+++ b/src/services/componentTemplateService.js
@@ -96,7 +96,7 @@ function getComponentScriptTemplate({ cmd, cliConfigFile, componentName, compone
   };
 }
 
-function getReducerScriptTemplate({ cmd, cliConfigFile, componentName, componentPathDir }) {
+function getReducerTemplate({ cmd, cliConfigFile, componentName, componentPathDir }) {
   const { usesTypeScript } = cliConfigFile;
   const { customTemplates } = cliConfigFile.reducer[cmd.type];
   let fileExtension = usesTypeScript ? 'tsx' : 'js';
@@ -128,7 +128,7 @@ function getReducerScriptTemplate({ cmd, cliConfigFile, componentName, component
   };
 }
 
-function getActionScriptTemplate({ cmd, cliConfigFile, componentName, componentPathDir }) {
+function getActionTemplate({ cmd, cliConfigFile, componentName, componentPathDir }) {
   const { usesTypeScript } = cliConfigFile;
   const { customTemplates } = cliConfigFile.action[cmd.type];
   let fileExtension = usesTypeScript ? 'tsx' : 'js';
@@ -302,8 +302,8 @@ const templateMap = {
   [componentTemplateTypes.STORY]: getComponentStoryTemplate,
   [componentTemplateTypes.LAZY]: getComponentLazyTemplate,
   [componentTemplateTypes.COMPONENT]: getComponentScriptTemplate,
-  [componentTemplateTypes.REDUCER]: getReducerScriptTemplate,
-  [componentTemplateTypes.ACTION]: getActionScriptTemplate,
+  [componentTemplateTypes.REDUCER]: getReducerTemplate,
+  [componentTemplateTypes.ACTION]: getActionTemplate,
 };
 
 function generateComponentTemplates(componentTemplates) {

--- a/src/services/componentTemplateService.js
+++ b/src/services/componentTemplateService.js
@@ -13,6 +13,8 @@ const componentStoryTemplate = require('../templates/component/componentStoryTem
 const componentTestEnzymeTemplate = require('../templates/component/componentTestEnzymeTemplate');
 const componentTestDefaultTemplate = require('../templates/component/componentTestDefaultTemplate');
 const componentTestTestingLibraryTemplate = require('../templates/component/componentTestTestingLibraryTemplate');
+const reducerTsTemplate = require('../templates/component/reducerTsTemplate');
+const actionTsTemplate = require('../templates/component/actionTsTemplate');
 
 // private
 
@@ -89,7 +91,71 @@ function getComponentScriptTemplate({ cmd, cliConfigFile, componentName, compone
   return {
     template,
     templateType: `Component "${componentName}.${fileExtension}"`,
-    componentPath: `${componentPathDir}/${componentName}.${fileExtension}`,
+    componentPath: `${componentPathDir}/index.${fileExtension}`,
+    componentName,
+  };
+}
+
+function getReducerScriptTemplate({ cmd, cliConfigFile, componentName, componentPathDir }) {
+  const { usesTypeScript } = cliConfigFile;
+  const { customTemplates } = cliConfigFile.reducer[cmd.type];
+  let fileExtension = usesTypeScript ? 'tsx' : 'js';
+  let template = null;
+
+  // Check for a custom component template.
+
+  if (customTemplates && customTemplates.reducer) {
+    // --- Load and use the custom component template
+
+    const { template: loadedTemplate, templateFileExtension } = loadCustomTemplate(customTemplates.reducer);
+
+    template = loadedTemplate;
+    fileExtension = templateFileExtension;
+  } else {
+    // --- Else use GRC built-in component template
+
+    template = usesTypeScript ? reducerTsTemplate : componentJsTemplate;
+
+    template = template.replace(` className={styles.TemplateName}`, '');
+    template = template.replace(`import styles from './TemplateName.module.css';`, '');
+  }
+
+  return {
+    template,
+    templateType: `Component "${componentName}.${fileExtension}"`,
+    componentPath: `${componentPathDir}/reducer.${fileExtension}`,
+    componentName,
+  };
+}
+
+function getActionScriptTemplate({ cmd, cliConfigFile, componentName, componentPathDir }) {
+  const { usesTypeScript } = cliConfigFile;
+  const { customTemplates } = cliConfigFile.action[cmd.type];
+  let fileExtension = usesTypeScript ? 'tsx' : 'js';
+  let template = null;
+
+  // Check for a custom action template.
+
+  if (customTemplates && customTemplates.action) {
+    // --- Load and use the custom action template
+
+    const { template: loadedTemplate, templateFileExtension } = loadCustomTemplate(customTemplates.action);
+
+    template = loadedTemplate;
+    fileExtension = templateFileExtension;
+  } else {
+    // --- Else use GRC built-in component template
+
+    template = usesTypeScript ? actionTsTemplate : componentJsTemplate;
+
+    template = template.replace(` className={styles.TemplateName}`, '');
+    template = template.replace(`import styles from './TemplateName.module.css';`, '');
+  }
+
+  return {
+    template,
+    templateType: `Component "${componentName}.${fileExtension}"`,
+    componentPath: `${componentPathDir}/action.${fileExtension}`,
     componentName,
   };
 }
@@ -224,6 +290,8 @@ const componentTemplateTypes = {
   STORY: 'withStory',
   LAZY: 'withLazy',
   COMPONENT: 'component',
+  REDUCER: 'reducer',
+  ACTION: 'action',
 };
 
 // --- Template Map
@@ -234,6 +302,8 @@ const templateMap = {
   [componentTemplateTypes.STORY]: getComponentStoryTemplate,
   [componentTemplateTypes.LAZY]: getComponentLazyTemplate,
   [componentTemplateTypes.COMPONENT]: getComponentScriptTemplate,
+  [componentTemplateTypes.REDUCER]: getReducerScriptTemplate,
+  [componentTemplateTypes.ACTION]: getActionScriptTemplate,
 };
 
 function generateComponentTemplates(componentTemplates) {

--- a/src/services/componentTemplateService.js
+++ b/src/services/componentTemplateService.js
@@ -98,7 +98,7 @@ function getComponentScriptTemplate({ cmd, cliConfigFile, componentName, compone
 
 function getReducerTemplate({ cmd, cliConfigFile, componentName, componentPathDir }) {
   const { usesTypeScript } = cliConfigFile;
-  const { customTemplates } = cliConfigFile.reducer[cmd.type];
+  const { customTemplates } = cliConfigFile.component[cmd.type];
   let fileExtension = usesTypeScript ? 'tsx' : 'js';
   let template = null;
 
@@ -130,7 +130,7 @@ function getReducerTemplate({ cmd, cliConfigFile, componentName, componentPathDi
 
 function getActionTemplate({ cmd, cliConfigFile, componentName, componentPathDir }) {
   const { usesTypeScript } = cliConfigFile;
-  const { customTemplates } = cliConfigFile.action[cmd.type];
+  const { customTemplates } = cliConfigFile.component[cmd.type];
   let fileExtension = usesTypeScript ? 'tsx' : 'js';
   let template = null;
 

--- a/src/services/componentTemplateService.js
+++ b/src/services/componentTemplateService.js
@@ -122,7 +122,7 @@ function getReducerScriptTemplate({ cmd, cliConfigFile, componentName, component
 
   return {
     template,
-    templateType: `Component "${componentName}.${fileExtension}"`,
+    templateType: `Reducer "${componentName}/reducer.${fileExtension}"`,
     componentPath: `${componentPathDir}/reducer.${fileExtension}`,
     componentName,
   };
@@ -154,7 +154,7 @@ function getActionScriptTemplate({ cmd, cliConfigFile, componentName, componentP
 
   return {
     template,
-    templateType: `Component "${componentName}.${fileExtension}"`,
+    templateType: `Action "${componentName}/action.${fileExtension}"`,
     componentPath: `${componentPathDir}/action.${fileExtension}`,
     componentName,
   };

--- a/src/templates/component/actionTsTemplate.js
+++ b/src/templates/component/actionTsTemplate.js
@@ -1,0 +1,18 @@
+module.exports = `
+import { createAction } from "@reduxjs/toolkit"
+
+// export interface ITemplateName {}
+
+export const createTemplateName = createAction<{ params: any }>(
+  "TemplateName/create"
+)
+export const readTemplateName = createAction<{ params: any }>(
+  "TemplateName/read"
+)
+export const updateTemplateName = createAction<{ params: any }>(
+  "TemplateName/update"
+)
+export const deleteTemplateName = createAction<{ params: any }>(
+  "TemplateName/delete"
+)
+`;

--- a/src/templates/component/reducerTsTemplate.js
+++ b/src/templates/component/reducerTsTemplate.js
@@ -1,0 +1,29 @@
+module.exports = `
+import { createReducer } from "@reduxjs/toolkit"
+import {
+  createTemplateName,
+  readTemplateName,
+  updateTemplateName,
+  deleteTemplateName,
+} from "./actions"
+
+export interface TemplateNameState {}
+
+export const initialState: TemplateNameState = {}
+
+export default createReducer(initialState, (builder) =>
+  builder
+    .addCase(createTemplateName, (state, action) => {
+      //
+    })
+    .addCase(readTemplateName, (state, action) => {
+      //
+    })
+    .addCase(updateTemplateName, (state, action) => {
+      //
+    })
+    .addCase(deleteTemplateName, (state, action) => {
+      //
+    })
+)
+`;


### PR DESCRIPTION
I'm going to create a lot of reducers and actions using this library and the naming (TemplateName) I will use for creating these is lowercase.

so using upperFirst function doesn't fit my needs
Is this function removable?
