### PR TITLE
Camel case replacement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,7 +221,7 @@ There is an optional `customTemplates` object that you can pass to the `componen
 },
 ```
 
-The keys represent the type of file, and the values are the paths that point to where your custom template lives in your project/system. Please note the `TemplateName` keyword in the template filename. GRC will use this keyword and replace it with your component name as the filename.
+The keys represent the type of file, and the values are the paths that point to where your custom template lives in your project/system. Please note the `TemplateName` keyword in the template filename. GRC will use this keyword and replace it with your component name as the filename. You can also use the keyword `templateName`, which will be replaced with your component name in camelCase.
 
 #### Example of using the `customTemplates` object within your generate-react-cli.json config file:
 

--- a/src/templates/component/componentTsTemplate.js
+++ b/src/templates/component/componentTsTemplate.js
@@ -1,7 +1,7 @@
 module.exports = `import React from 'react';
 import styles from './TemplateName.module.css';
 
-const TemplateName: React.FC = () => (
+const TemplateName = () => (
   <div className={styles.TemplateName} data-testid="TemplateName">
     TemplateName Component
   </div>

--- a/src/utils/generateComponentUtils.js
+++ b/src/utils/generateComponentUtils.js
@@ -365,6 +365,14 @@ function generateComponent(componentName, cmd, cliConfigFile) {
             silent: true,
           });
 
+          replace({
+            regex: 'templateName',
+            replacement: camelCase(componentName),
+            paths: [componentPath],
+            recursive: false,
+            silent: true,
+          });
+
           console.log(chalk.green(`${filename} was successfully created at ${componentPath}`));
         } catch (error) {
           console.error(chalk.red(`${filename} failed and was not created.`));


### PR DESCRIPTION
Added the possibility to use `templateName` to replace the given component name as camelCase in custom templates.

Updated the Readme to reflect this.

--> This would close issue #43 

Changed the default TypeScript template to not use `React.FC` anymore, since its not recommended anymore.