### PR TITLE
refactor(story): update to modern storybook syntax

### DIFF
--- a/src/templates/component/componentStoryTemplate.js
+++ b/src/templates/component/componentStoryTemplate.js
@@ -3,9 +3,11 @@ import TemplateName from './TemplateName';
 
 export default {
   title: "TemplateName",
-  component: TemplateName,
 };
 
-export const Template = TemplateName.bind({});
-Template.args = {};
+export const Default = () => <TemplateName />;
+
+Default.story = {
+  name: 'default',
+};
 `;

--- a/src/templates/component/componentStoryTemplate.js
+++ b/src/templates/component/componentStoryTemplate.js
@@ -1,7 +1,11 @@
 module.exports = `/* eslint-disable */
-import React from 'react';
-import { storiesOf } from '@storybook/react';
 import TemplateName from './TemplateName';
 
-storiesOf('TemplateName', module).add('default', () => <TemplateName />);
+export default {
+  title: "TemplateName",
+  component: TemplateName,
+};
+
+export const Template = TemplateName.bind({});
+Template.args = {};
 `;


### PR DESCRIPTION
Storybook team is advising developers to migrate away from storiesOf API, as per this doc: https://github.com/storybookjs/storybook/blob/next/lib/core/docs/storiesOf.md. 

This commit upgrades the stories template to this modern syntax.