### PR TITLE
feat: adds dry-run flag to preview generated paths without writing files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,14 @@ Otherwise, if you don't pass any options, it will just use the default values th
     <td width="20%">Boolean</td>
     <td width="20%"><code>component.default.withTest<code></td>
   </tr>
+  <tr>
+    <td width="20%"><b>--dry-run</b></td>
+    <td width="60%">
+      Show what will be generated without writing to disk
+    </td>
+    <td width="20%">Boolean</td>
+    <td width="20%"><code>false<code></td>
+  </tr>
 </table>
 
 ### Custom component types:

--- a/src/commands/generateComponent.js
+++ b/src/commands/generateComponent.js
@@ -34,6 +34,8 @@ function initGenerateComponentCommand(args, cliConfigFile, program) {
     );
   });
 
+  componentCommand.option('--dry-run', 'Show what will be generated without writing to disk')
+
   // Component command action.
 
   componentCommand.action((componentNames, cmd) =>

--- a/src/utils/generateComponentUtils.js
+++ b/src/utils/generateComponentUtils.js
@@ -355,39 +355,41 @@ function generateComponent(componentName, cmd, cliConfigFile) {
         console.error(chalk.red(`${filename} already exists in this path "${componentPath}".`));
       } else {
         try {
-          outputFileSync(componentPath, template);
+          if (!cmd.dryRun) {
+            outputFileSync(componentPath, template);
 
-          replace({
-            regex: 'TemplateName',
-            replacement: componentName,
-            paths: [componentPath],
-            recursive: false,
-            silent: true,
-          });
+            replace({
+              regex: 'TemplateName',
+              replacement: componentName,
+              paths: [componentPath],
+              recursive: false,
+              silent: true,
+            });
 
-          replace({
-            regex: 'templateName',
-            replacement: camelCase(componentName),
-            paths: [componentPath],
-            recursive: false,
-            silent: true,
-          });
+            replace({
+              regex: 'templateName',
+              replacement: camelCase(componentName),
+              paths: [componentPath],
+              recursive: false,
+              silent: true,
+            });
 
-          replace({
-            regex: 'template-name',
-            replacement: kebabCase(componentName),
-            paths: [componentPath],
-            recursive: false,
-            silent: true,
-          });
+            replace({
+              regex: 'template-name',
+              replacement: kebabCase(componentName),
+              paths: [componentPath],
+              recursive: false,
+              silent: true,
+            });
 
-          replace({
-            regex: 'template_name',
-            replacement: snakeCase(componentName),
-            paths: [componentPath],
-            recursive: false,
-            silent: true,
-          });
+            replace({
+              regex: 'template_name',
+              replacement: snakeCase(componentName),
+              paths: [componentPath],
+              recursive: false,
+              silent: true,
+            });
+          }
 
           console.log(chalk.green(`${filename} was successfully created at ${componentPath}`));
         } catch (error) {
@@ -397,6 +399,11 @@ function generateComponent(componentName, cmd, cliConfigFile) {
       }
     }
   });
+
+  if (cmd.dryRun) {
+    console.log()
+    console.log(chalk.yellow(`NOTE: The "dry-run" flag means no changes were made.`))
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
@arminbro this changes adds support for a `--dry-run` flag. This allows you to preview the paths of the files which are generated before actually writing the files.  By default the flag is false.

Sample execution:
```
❯ npx generate-react-cli component Foo --dry-run
Foo.tsx was successfully created at src/components/Foo/Foo.tsx
Foo.module.css was successfully created at src/components/Foo/Foo.module.css
Foo.test.tsx was successfully created at src/components/Foo/Foo.test.tsx
Foo.stories.tsx was successfully created at src/components/Foo/Foo.stories.tsx
Foo.lazy.tsx was successfully created at src/components/Foo/Foo.lazy.tsx

NOTE: The "dry-run" flag means no changes were made.
```

Let me know if you have any questions. Thanks for considering this pull request.