### PR TITLE
feat: Adds support for uppercase snake case TEMPLATE_NAME

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -235,11 +235,12 @@ The keys represent the type of file, and the values are the paths that point to 
 
 You can also use the following keywords, which will be replaced with their corresponding formatted component name:
 
-| Keyword         | Replacement                  |
-|-----------------|------------------------------|
-| `templateName`  | component name in camelCase  |
-| `template-name` | component name in kebab-case |
-| `template_name` | component name in snake_case |
+| Keyword         | Replacement                            |
+|-----------------|----------------------------------------|
+| `templateName`  | component name in camelCase            |
+| `template-name` | component name in kebab-case           |
+| `template_name` | component name in snake_case           |
+| `TEMPLATE_NAME` | component name in uppercase SNAKE_CASE |
 
 #### Example of using the `customTemplates` object within your generate-react-cli.json config file:
 

--- a/src/utils/generateComponentUtils.js
+++ b/src/utils/generateComponentUtils.js
@@ -389,6 +389,14 @@ function generateComponent(componentName, cmd, cliConfigFile) {
               recursive: false,
               silent: true,
             });
+
+            replace({
+              regex: 'TEMPLATE_NAME',
+              replacement: snakeCase(componentName).toUpperCase(),
+              paths: [componentPath],
+              recursive: false,
+              silent: true,
+            });
           }
 
           console.log(chalk.green(`${filename} was successfully created at ${componentPath}`));


### PR DESCRIPTION
Hey, I would like to use `generate-react-cli` for creating redux action types files, like this one:

```js
// src/redux/actionTypes.js

export const GET_TEMPLATE_NAME_REQUEST = 'GET_TEMPLATE_NAME_REQUEST';
export const GET_TEMPLATE_NAME_SUCCESS = 'GET_TEMPLATE_NAME_SUCCESS';
export const GET_TEMPLATE_NAME_FAILURE = 'GET_TEMPLATE_NAME_FAILURE';
```

This PR adds possibility to do so.