### PR TITLE
fix-#64 - Add option to avoid new folder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,14 @@ Otherwise, if you don't pass any options, it will just use the default values th
     <td width="20%">Boolean</td>
     <td width="20%"><code>false<code></td>
   </tr>
+  <tr>
+    <td width="20%"><b>--flat</b></td>
+    <td width="60%">
+      Generate the files in the mentioned path insted of creating new folder for it
+    </td>
+    <td width="20%">Boolean</td>
+    <td width="20%"><code>false<code></td>
+  </tr>
 </table>
 
 ### Custom component types:

--- a/src/commands/generateComponent.js
+++ b/src/commands/generateComponent.js
@@ -2,12 +2,10 @@ const {
   generateComponent,
   getComponentByType,
   getCorrespondingComponentFileTypes,
-  checkIsFlat,
 } = require('../utils/generateComponentUtils');
 
 function initGenerateComponentCommand(args, cliConfigFile, program) {
   const selectedComponentType = getComponentByType(args, cliConfigFile);
-  const isFlat = checkIsFlat(args);
 
   const componentCommand = program
     .command('component [names...]')
@@ -40,7 +38,7 @@ function initGenerateComponentCommand(args, cliConfigFile, program) {
   // Component command action.
 
   componentCommand.action((componentNames, cmd) =>
-    componentNames.forEach((componentName) => generateComponent(componentName, cmd, cliConfigFile, isFlat))
+    componentNames.forEach((componentName) => generateComponent(componentName, cmd, cliConfigFile))
   );
 }
 

--- a/src/commands/generateComponent.js
+++ b/src/commands/generateComponent.js
@@ -2,10 +2,12 @@ const {
   generateComponent,
   getComponentByType,
   getCorrespondingComponentFileTypes,
+  checkIsFlat,
 } = require('../utils/generateComponentUtils');
 
 function initGenerateComponentCommand(args, cliConfigFile, program) {
   const selectedComponentType = getComponentByType(args, cliConfigFile);
+  const isFlat = checkIsFlat(args);
 
   const componentCommand = program
     .command('component [names...]')
@@ -18,7 +20,8 @@ function initGenerateComponentCommand(args, cliConfigFile, program) {
       '--type <type>',
       'You can pass a component type that you have configured in your GRC config file.',
       'default'
-    );
+    )
+    .option('-f, --flat', 'Generate the files in the mentioned path insted of creating new folder for it', false);
 
   // Dynamic component command option defaults.
 
@@ -37,7 +40,7 @@ function initGenerateComponentCommand(args, cliConfigFile, program) {
   // Component command action.
 
   componentCommand.action((componentNames, cmd) =>
-    componentNames.forEach((componentName) => generateComponent(componentName, cmd, cliConfigFile))
+    componentNames.forEach((componentName) => generateComponent(componentName, cmd, cliConfigFile, isFlat))
   );
 }
 

--- a/src/utils/generateComponentUtils.js
+++ b/src/utils/generateComponentUtils.js
@@ -74,7 +74,7 @@ Please make sure you're pointing to the right custom template path in your gener
   }
 }
 
-function componentTemplateGenerator({ cmd, componentName, cliConfigFile, isFlat }) {
+function componentTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   const { cssPreprocessor, testLibrary, usesCssModule, usesTypeScript } = cliConfigFile;
   const { customTemplates } = cliConfigFile.component[cmd.type];
   let template = null;
@@ -127,13 +127,13 @@ function componentTemplateGenerator({ cmd, componentName, cliConfigFile, isFlat 
   }
 
   return {
-    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
-function componentStyleTemplateGenerator({ cliConfigFile, cmd, componentName, isFlat }) {
+function componentStyleTemplateGenerator({ cliConfigFile, cmd, componentName }) {
   const { customTemplates } = cliConfigFile.component[cmd.type];
   let template = null;
   let filename = null;
@@ -162,13 +162,13 @@ function componentStyleTemplateGenerator({ cliConfigFile, cmd, componentName, is
   }
 
   return {
-    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
-function componentTestTemplateGenerator({ cliConfigFile, cmd, componentName, isFlat }) {
+function componentTestTemplateGenerator({ cliConfigFile, cmd, componentName }) {
   const { customTemplates } = cliConfigFile.component[cmd.type];
   const { testLibrary, usesTypeScript } = cliConfigFile;
   let template = null;
@@ -201,13 +201,13 @@ function componentTestTemplateGenerator({ cliConfigFile, cmd, componentName, isF
   }
 
   return {
-    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
-function componentStoryTemplateGenerator({ cliConfigFile, cmd, componentName, isFlat }) {
+function componentStoryTemplateGenerator({ cliConfigFile, cmd, componentName }) {
   const { usesTypeScript } = cliConfigFile;
   const { customTemplates } = cliConfigFile.component[cmd.type];
   let template = null;
@@ -233,13 +233,13 @@ function componentStoryTemplateGenerator({ cliConfigFile, cmd, componentName, is
   }
 
   return {
-    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
-function componentLazyTemplateGenerator({ cmd, componentName, cliConfigFile, isFlat }) {
+function componentLazyTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   const { usesTypeScript } = cliConfigFile;
   const { customTemplates } = cliConfigFile.component[cmd.type];
   let template = null;
@@ -265,13 +265,13 @@ function componentLazyTemplateGenerator({ cmd, componentName, cliConfigFile, isF
   }
 
   return {
-    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
-function customFileTemplateGenerator({ componentName, cmd, cliConfigFile, componentFileType, isFlat }) {
+function customFileTemplateGenerator({ componentName, cmd, cliConfigFile, componentFileType }) {
   const { customTemplates } = cliConfigFile.component[cmd.type];
   const fileType = camelCase(componentFileType.split('with')[1]);
   let filename = null;
@@ -303,7 +303,7 @@ Please make sure you're pointing to the right custom template path in your gener
   filename = customTemplateFilename;
 
   return {
-    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
@@ -329,7 +329,7 @@ const componentTemplateGeneratorMap = {
   [buildInComponentFileTypes.LAZY]: componentLazyTemplateGenerator,
 };
 
-function generateComponent(componentName, cmd, cliConfigFile, isFlat) {
+function generateComponent(componentName, cmd, cliConfigFile) {
   const componentFileTypes = ['component', ...getCorrespondingComponentFileTypes(cmd)];
 
   componentFileTypes.forEach((componentFileType) => {
@@ -347,7 +347,6 @@ function generateComponent(componentName, cmd, cliConfigFile, isFlat) {
         componentName,
         cliConfigFile,
         componentFileType,
-        isFlat,
       });
 
       // --- Make sure the component does not already exist in the path directory.
@@ -429,13 +428,8 @@ function generateComponent(componentName, cmd, cliConfigFile, isFlat) {
   }
 }
 
-function checkIsFlat(args) {
-  return args.find((arg) => arg.includes('-f') || arg.includes('--flat'));
-}
-
 module.exports = {
   generateComponent,
   getComponentByType,
   getCorrespondingComponentFileTypes,
-  checkIsFlat,
 };

--- a/src/utils/generateComponentUtils.js
+++ b/src/utils/generateComponentUtils.js
@@ -74,7 +74,7 @@ Please make sure you're pointing to the right custom template path in your gener
   }
 }
 
-function componentTemplateGenerator({ cmd, componentName, cliConfigFile }) {
+function componentTemplateGenerator({ cmd, componentName, cliConfigFile, isFlat }) {
   const { cssPreprocessor, testLibrary, usesCssModule, usesTypeScript } = cliConfigFile;
   const { customTemplates } = cliConfigFile.component[cmd.type];
   let template = null;
@@ -127,13 +127,13 @@ function componentTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   }
 
   return {
-    componentPath: `${cmd.path}/${componentName}/${filename}`,
+    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
-function componentStyleTemplateGenerator({ cliConfigFile, cmd, componentName }) {
+function componentStyleTemplateGenerator({ cliConfigFile, cmd, componentName, isFlat }) {
   const { customTemplates } = cliConfigFile.component[cmd.type];
   let template = null;
   let filename = null;
@@ -162,13 +162,13 @@ function componentStyleTemplateGenerator({ cliConfigFile, cmd, componentName }) 
   }
 
   return {
-    componentPath: `${cmd.path}/${componentName}/${filename}`,
+    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
-function componentTestTemplateGenerator({ cliConfigFile, cmd, componentName }) {
+function componentTestTemplateGenerator({ cliConfigFile, cmd, componentName, isFlat }) {
   const { customTemplates } = cliConfigFile.component[cmd.type];
   const { testLibrary, usesTypeScript } = cliConfigFile;
   let template = null;
@@ -201,13 +201,13 @@ function componentTestTemplateGenerator({ cliConfigFile, cmd, componentName }) {
   }
 
   return {
-    componentPath: `${cmd.path}/${componentName}/${filename}`,
+    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
-function componentStoryTemplateGenerator({ cliConfigFile, cmd, componentName }) {
+function componentStoryTemplateGenerator({ cliConfigFile, cmd, componentName, isFlat }) {
   const { usesTypeScript } = cliConfigFile;
   const { customTemplates } = cliConfigFile.component[cmd.type];
   let template = null;
@@ -233,13 +233,13 @@ function componentStoryTemplateGenerator({ cliConfigFile, cmd, componentName }) 
   }
 
   return {
-    componentPath: `${cmd.path}/${componentName}/${filename}`,
+    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
-function componentLazyTemplateGenerator({ cmd, componentName, cliConfigFile }) {
+function componentLazyTemplateGenerator({ cmd, componentName, cliConfigFile, isFlat }) {
   const { usesTypeScript } = cliConfigFile;
   const { customTemplates } = cliConfigFile.component[cmd.type];
   let template = null;
@@ -265,13 +265,13 @@ function componentLazyTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   }
 
   return {
-    componentPath: `${cmd.path}/${componentName}/${filename}`,
+    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
-function customFileTemplateGenerator({ componentName, cmd, cliConfigFile, componentFileType }) {
+function customFileTemplateGenerator({ componentName, cmd, cliConfigFile, componentFileType, isFlat }) {
   const { customTemplates } = cliConfigFile.component[cmd.type];
   const fileType = camelCase(componentFileType.split('with')[1]);
   let filename = null;
@@ -303,7 +303,7 @@ Please make sure you're pointing to the right custom template path in your gener
   filename = customTemplateFilename;
 
   return {
-    componentPath: `${cmd.path}/${componentName}/${filename}`,
+    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
@@ -329,7 +329,7 @@ const componentTemplateGeneratorMap = {
   [buildInComponentFileTypes.LAZY]: componentLazyTemplateGenerator,
 };
 
-function generateComponent(componentName, cmd, cliConfigFile) {
+function generateComponent(componentName, cmd, cliConfigFile, isFlat) {
   const componentFileTypes = ['component', ...getCorrespondingComponentFileTypes(cmd)];
 
   componentFileTypes.forEach((componentFileType) => {
@@ -347,6 +347,7 @@ function generateComponent(componentName, cmd, cliConfigFile) {
         componentName,
         cliConfigFile,
         componentFileType,
+        isFlat,
       });
 
       // --- Make sure the component does not already exist in the path directory.
@@ -428,8 +429,13 @@ function generateComponent(componentName, cmd, cliConfigFile) {
   }
 }
 
+function checkIsFlat(args) {
+  return args.find((arg) => arg.includes('-f') || arg.includes('--flat'));
+}
+
 module.exports = {
   generateComponent,
   getComponentByType,
   getCorrespondingComponentFileTypes,
+  checkIsFlat,
 };


### PR DESCRIPTION
Added an extra option `-f` or `--flat` to create the files in the same folder without creating new folder in the name of the component.

This will fix the feature request of #64