### PR TITLE
feat: allow user to create component with srouce file name index.tsx

### DIFF
--- a/src/utils/generateComponentUtils.js
+++ b/src/utils/generateComponentUtils.js
@@ -86,6 +86,9 @@ function componentTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   let template = null;
   let filename = null;
 
+  // allow naming the component src file as ComponentName/index.jsx
+  componentName = cmd.withNameIndex ? 'index' : componentName;
+
   // Check for a custom component template.
 
   if (customTemplates && customTemplates.component) {


### PR DESCRIPTION
some user needs to name the component src file as ComponentName/index.tsx. Adding one extra option at the component level for different naming conventions.
Please see the [poll ](https://www.reddit.com/r/reactjs/comments/snmyt3/do_you_name_your_component_file_indexjs_or/) on Reddit.
 
Not adding another componentLevelQuestions because there are already a lot of questions at the first run.
```
  // allow naming the component src file as ComponentName/index.jsx
  componentName = cmd.withNameIndex ? 'index' : componentName;
```