### PR TITLE
feat: Allow Flat Property within JSON

### DIFF
--- a/src/commands/generateComponent.js
+++ b/src/commands/generateComponent.js
@@ -24,7 +24,11 @@ export default function initGenerateComponentCommand(args, cliConfigFile, progra
       'Describe the component you want GRC to generate (e.g., Create a counter component that increments by one when I click on the increment button).',
       null
     )
-    .option('-f, --flat', 'Generate the files in the mentioned path insted of creating new folder for it', false)
+    .option(
+      '-f, --flat',
+      'Generate the files in the mentioned path instead of creating new folder for it',
+      selectedComponentType.flat || false
+    )
     .option('-dr, --dry-run', 'Show what will be generated without writing to disk');
 
   // Dynamic component command option defaults.

--- a/src/utils/generateComponentUtils.js
+++ b/src/utils/generateComponentUtils.js
@@ -82,9 +82,10 @@ Please make sure you're pointing to the right custom template path in your gener
 
 function componentTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   const { cssPreprocessor, testLibrary, usesCssModule, usesTypeScript } = cliConfigFile;
-  const { customTemplates } = cliConfigFile.component[cmd.type];
+  const { customTemplates, flat } = cliConfigFile.component[cmd.type];
   let template = null;
   let filename = null;
+  const isFlat = flat || cmd.flat;
 
   // Check for a custom component template.
 
@@ -133,16 +134,17 @@ function componentTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   }
 
   return {
-    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
 function componentStyleTemplateGenerator({ cliConfigFile, cmd, componentName }) {
-  const { customTemplates } = cliConfigFile.component[cmd.type];
+  const { customTemplates, flat } = cliConfigFile.component[cmd.type];
   let template = null;
   let filename = null;
+  const isFlat = flat || cmd.flat;
 
   // Check for a custom style template.
 
@@ -168,17 +170,18 @@ function componentStyleTemplateGenerator({ cliConfigFile, cmd, componentName }) 
   }
 
   return {
-    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
 function componentTestTemplateGenerator({ cliConfigFile, cmd, componentName }) {
-  const { customTemplates } = cliConfigFile.component[cmd.type];
+  const { customTemplates, flat } = cliConfigFile.component[cmd.type];
   const { testLibrary, usesTypeScript } = cliConfigFile;
   let template = null;
   let filename = null;
+  const isFlat = flat || cmd.flat;
 
   // Check for a custom test template.
 
@@ -207,7 +210,7 @@ function componentTestTemplateGenerator({ cliConfigFile, cmd, componentName }) {
   }
 
   return {
-    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
@@ -215,9 +218,10 @@ function componentTestTemplateGenerator({ cliConfigFile, cmd, componentName }) {
 
 function componentStoryTemplateGenerator({ cliConfigFile, cmd, componentName }) {
   const { usesTypeScript } = cliConfigFile;
-  const { customTemplates } = cliConfigFile.component[cmd.type];
+  const { customTemplates, flat } = cliConfigFile.component[cmd.type];
   let template = null;
   let filename = null;
+  const isFlat = flat || cmd.flat;
 
   // Check for a custom story template.
 
@@ -239,7 +243,7 @@ function componentStoryTemplateGenerator({ cliConfigFile, cmd, componentName }) 
   }
 
   return {
-    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
@@ -247,9 +251,10 @@ function componentStoryTemplateGenerator({ cliConfigFile, cmd, componentName }) 
 
 function componentLazyTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   const { usesTypeScript } = cliConfigFile;
-  const { customTemplates } = cliConfigFile.component[cmd.type];
+  const { customTemplates, flat } = cliConfigFile.component[cmd.type];
   let template = null;
   let filename = null;
+  const isFlat = flat || cmd.flat;
 
   // Check for a custom lazy template.
 
@@ -271,17 +276,18 @@ function componentLazyTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   }
 
   return {
-    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
 function customFileTemplateGenerator({ componentName, cmd, cliConfigFile, componentFileType }) {
-  const { customTemplates } = cliConfigFile.component[cmd.type];
+  const { customTemplates, flat } = cliConfigFile.component[cmd.type];
   const fileType = camelCase(componentFileType.split('with')[1]);
   let filename = null;
   let template = null;
+  const isFlat = flat || cmd.flat;
 
   // Check for a valid custom template for the corresponding custom component file.
 
@@ -309,7 +315,7 @@ Please make sure you're pointing to the right custom template path in your gener
   filename = customTemplateFilename;
 
   return {
-    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };

--- a/src/utils/generateComponentUtils.js
+++ b/src/utils/generateComponentUtils.js
@@ -82,10 +82,9 @@ Please make sure you're pointing to the right custom template path in your gener
 
 function componentTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   const { cssPreprocessor, testLibrary, usesCssModule, usesTypeScript } = cliConfigFile;
-  const { customTemplates, flat } = cliConfigFile.component[cmd.type];
+  const { customTemplates } = cliConfigFile.component[cmd.type];
   let template = null;
   let filename = null;
-  const isFlat = flat || cmd.flat;
 
   // Check for a custom component template.
 
@@ -134,17 +133,16 @@ function componentTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   }
 
   return {
-    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
 function componentStyleTemplateGenerator({ cliConfigFile, cmd, componentName }) {
-  const { customTemplates, flat } = cliConfigFile.component[cmd.type];
+  const { customTemplates } = cliConfigFile.component[cmd.type];
   let template = null;
   let filename = null;
-  const isFlat = flat || cmd.flat;
 
   // Check for a custom style template.
 
@@ -170,18 +168,17 @@ function componentStyleTemplateGenerator({ cliConfigFile, cmd, componentName }) 
   }
 
   return {
-    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
 function componentTestTemplateGenerator({ cliConfigFile, cmd, componentName }) {
-  const { customTemplates, flat } = cliConfigFile.component[cmd.type];
+  const { customTemplates } = cliConfigFile.component[cmd.type];
   const { testLibrary, usesTypeScript } = cliConfigFile;
   let template = null;
   let filename = null;
-  const isFlat = flat || cmd.flat;
 
   // Check for a custom test template.
 
@@ -210,7 +207,7 @@ function componentTestTemplateGenerator({ cliConfigFile, cmd, componentName }) {
   }
 
   return {
-    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
@@ -218,10 +215,9 @@ function componentTestTemplateGenerator({ cliConfigFile, cmd, componentName }) {
 
 function componentStoryTemplateGenerator({ cliConfigFile, cmd, componentName }) {
   const { usesTypeScript } = cliConfigFile;
-  const { customTemplates, flat } = cliConfigFile.component[cmd.type];
+  const { customTemplates } = cliConfigFile.component[cmd.type];
   let template = null;
   let filename = null;
-  const isFlat = flat || cmd.flat;
 
   // Check for a custom story template.
 
@@ -243,7 +239,7 @@ function componentStoryTemplateGenerator({ cliConfigFile, cmd, componentName }) 
   }
 
   return {
-    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
@@ -251,10 +247,9 @@ function componentStoryTemplateGenerator({ cliConfigFile, cmd, componentName }) 
 
 function componentLazyTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   const { usesTypeScript } = cliConfigFile;
-  const { customTemplates, flat } = cliConfigFile.component[cmd.type];
+  const { customTemplates } = cliConfigFile.component[cmd.type];
   let template = null;
   let filename = null;
-  const isFlat = flat || cmd.flat;
 
   // Check for a custom lazy template.
 
@@ -276,18 +271,17 @@ function componentLazyTemplateGenerator({ cmd, componentName, cliConfigFile }) {
   }
 
   return {
-    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };
 }
 
 function customFileTemplateGenerator({ componentName, cmd, cliConfigFile, componentFileType }) {
-  const { customTemplates, flat } = cliConfigFile.component[cmd.type];
+  const { customTemplates } = cliConfigFile.component[cmd.type];
   const fileType = camelCase(componentFileType.split('with')[1]);
   let filename = null;
   let template = null;
-  const isFlat = flat || cmd.flat;
 
   // Check for a valid custom template for the corresponding custom component file.
 
@@ -315,7 +309,7 @@ Please make sure you're pointing to the right custom template path in your gener
   filename = customTemplateFilename;
 
   return {
-    componentPath: `${cmd.path}${isFlat ? '' : `/${componentName}`}/${filename}`,
+    componentPath: `${cmd.path}${cmd.flat ? '' : `/${componentName}`}/${filename}`,
     filename,
     template,
   };


### PR DESCRIPTION
I've added an OR check to see if the `flat` property is specified within the `.JSON` file as well as the existing command. This is helpful so you don't have to remember to add it to commands and it can be abstracted away from the command line.

My main use for this is when generating either hooks or slices, having flat pre-defined within the JSON file just makes my life a smidge easier. Thanks for the package though as I use it so often and this would just be the icing on top 🍰

Example:
<img width="430" alt="Screenshot 2023-01-02 at 19 19 09" src="https://user-images.githubusercontent.com/9806346/210271280-161873c7-555a-472c-a534-8bb7d2a16a47.png">
