### PR TITLE
feat: styled-components support

### DIFF
--- a/src/templates/component/componentStyledTemplate.js
+++ b/src/templates/component/componentStyledTemplate.js
@@ -1,0 +1,5 @@
+export default `import styled from 'styled-components';
+
+export const TemplateNameWrapper = styled.div\`
+\`;
+`;

--- a/src/utils/grcConfigUtils.js
+++ b/src/utils/grcConfigUtils.js
@@ -20,12 +20,19 @@ const projectLevelQuestions = [
   },
   {
     type: 'confirm',
+    name: 'usesStyledComponents',
+    message: 'Does this project use styled-components?',
+  },
+  {
+    type: 'confirm',
+    when: (answers) => !answers['usesStyledComponents'],
     name: 'usesCssModule',
     message: 'Does this project use CSS modules?',
   },
   {
     type: 'list',
     name: 'cssPreprocessor',
+    when: (answers) => !answers['usesStyledComponents'],
     message: 'Does this project use a CSS Preprocessor?',
     choices: ['css', 'scss', 'less', 'styl'],
   },
@@ -184,7 +191,9 @@ export async function getCLIConfigFile() {
        */
 
       const missingConfigQuestions = grcConfigQuestions.filter(
-        (question) => !deepKeys(currentConfigFile).includes(question.name)
+        (question) =>
+          !deepKeys(currentConfigFile).includes(question.name) &&
+          (question.when ? question.when(currentConfigFile) : true)
       );
 
       if (missingConfigQuestions.length) {


### PR DESCRIPTION
Adds an option to use [styled-components](https://styled-components.com/) instead of CSS modules. 

During setup:
- Ask user "Does this project use styled-components?"
- If the answer is yes, skip "Does this project use CSS modules?" and "Does this project use a CSS Preprocessor?" 

During component creation: 
- Use the existing `withStyle` setting to determine whether to generate a styled component in this instance
- If `withStyle` is true:
  - the `div` in the template is replaced by a `ComponentNameWrapper`, and 
  - a corresponding `ComponentName.styled.{js,ts}` file is created, defining `ComponentNameWrapper` as a `div`.

Could close #48.