### PR TITLE
Fix an issue with the type of case in the custom file names

### DIFF
--- a/src/utils/generateComponentUtils.js
+++ b/src/utils/generateComponentUtils.js
@@ -65,7 +65,7 @@ function getCustomTemplate(componentName, templatePath) {
 
   try {
     const template = readFileSync(templatePath, 'utf8');
-    const filename = path.basename(templatePath).replace('TemplateName', componentName);
+    const filename = path.basename(templatePath).replace(/template[|_-]?name/i, componentName);
 
     return { template, filename };
   } catch (e) {


### PR DESCRIPTION
File names like template-name, template_name etc. are working fine