### PR TITLE
fix: remove AI features and fix Commander v14 compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.11.1'
+          node-version: '20.19.4'
       - run: npm ci
       - run: npx semantic-release
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 
 # ide
 .idea
+
+# Claude AI context file
+**/CLAUDE.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
         "generate-react": "bin/generate-react.js"
       },
       "devDependencies": {
-        "@commitlint/cli": "19.5.0",
-        "@commitlint/config-conventional": "19.5.0",
+        "@commitlint/cli": "19.8.1",
+        "@commitlint/config-conventional": "19.8.1",
         "@semantic-release/commit-analyzer": "13.0.0",
         "@semantic-release/git": "10.0.1",
         "@semantic-release/github": "11.0.0",
@@ -211,18 +211,18 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.5.0.tgz",
-      "integrity": "sha512-gaGqSliGwB86MDmAAKAtV9SV1SHdmN8pnGq4EJU4+hLisQ7IFfx4jvU4s+pk6tl0+9bv6yT+CaZkufOinkSJIQ==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.1.tgz",
+      "integrity": "sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/format": "^19.5.0",
-        "@commitlint/lint": "^19.5.0",
-        "@commitlint/load": "^19.5.0",
-        "@commitlint/read": "^19.5.0",
-        "@commitlint/types": "^19.5.0",
-        "tinyexec": "^0.3.0",
+        "@commitlint/format": "^19.8.1",
+        "@commitlint/lint": "^19.8.1",
+        "@commitlint/load": "^19.8.1",
+        "@commitlint/read": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
+        "tinyexec": "^1.0.0",
         "yargs": "^17.0.0"
       },
       "bin": {
@@ -232,14 +232,21 @@
         "node": ">=v18"
       }
     },
+    "node_modules/@commitlint/cli/node_modules/tinyexec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@commitlint/config-conventional": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.5.0.tgz",
-      "integrity": "sha512-OBhdtJyHNPryZKg0fFpZNOBM1ZDbntMvqMuSmpfyP86XSfwzGw4CaoYRG4RutUPg0BTK07VMRIkNJT6wi2zthg==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.1.tgz",
+      "integrity": "sha512-/AZHJL6F6B/G959CsMAzrPKKZjeEiAVifRyEwXxcT6qtqbPwGw+iQxmNS+Bu+i09OCtdNRW6pNpBvgPrtMr9EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.1",
         "conventional-changelog-conventionalcommits": "^7.0.2"
       },
       "engines": {
@@ -247,13 +254,13 @@
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.5.0.tgz",
-      "integrity": "sha512-CHtj92H5rdhKt17RmgALhfQt95VayrUo2tSqY9g2w+laAXyk7K/Ef6uPm9tn5qSIwSmrLjKaXK9eiNuxmQrDBw==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz",
+      "integrity": "sha512-0jvJ4u+eqGPBIzzSdqKNX1rvdbSU1lPNYlfQQRIFnBgLy26BtC0cFnr7c/AyuzExMxWsMOte6MkTi9I3SQ3iGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.1",
         "ajv": "^8.11.0"
       },
       "engines": {
@@ -261,13 +268,13 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.5.0.tgz",
-      "integrity": "sha512-Kv0pYZeMrdg48bHFEU5KKcccRfKmISSm9MvgIgkpI6m+ohFTB55qZlBW6eYqh/XDfRuIO0x4zSmvBjmOwWTwkg==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.1.tgz",
+      "integrity": "sha512-mXDnlJdvDzSObafjYrOSvZBwkD01cqB4gbnnFuVyNpGUM5ijwU/r/6uqUmBXAAOKRfyEjpkGVZxaDsCVnHAgyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.1",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.snakecase": "^4.1.1",
@@ -279,9 +286,9 @@
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.5.0.tgz",
-      "integrity": "sha512-aqyGgytXhl2ejlk+/rfgtwpPexYyri4t8/n4ku6rRJoRhGZpLFMqrZ+YaubeGysCP6oz4mMA34YSTaSOKEeNrg==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.1.tgz",
+      "integrity": "sha512-YfJyIqIKWI64Mgvn/sE7FXvVMQER/Cd+s3hZke6cI1xgNT/f6ZAz5heND0QtffH+KbcqAwXDEE1/5niYayYaQA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -289,13 +296,13 @@
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.5.0.tgz",
-      "integrity": "sha512-yNy088miE52stCI3dhG/vvxFo9e4jFkU1Mj3xECfzp/bIS/JUay4491huAlVcffOoMK1cd296q0W92NlER6r3A==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.1.tgz",
+      "integrity": "sha512-kSJj34Rp10ItP+Eh9oCItiuN/HwGQMXBnIRk69jdOwEW9llW9FlyqcWYbHPSGofmjsqeoxa38UaEA5tsbm2JWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.1",
         "chalk": "^5.3.0"
       },
       "engines": {
@@ -303,13 +310,13 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.5.0.tgz",
-      "integrity": "sha512-0XQ7Llsf9iL/ANtwyZ6G0NGp5Y3EQ8eDQSxv/SRcfJ0awlBY4tHFAvwWbw66FVUaWICH7iE5en+FD9TQsokZ5w==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.1.tgz",
+      "integrity": "sha512-AceOhEhekBUQ5dzrVhDDsbMaY5LqtN8s1mqSnT2Kz1ERvVZkNihrs3Sfk1Je/rxRNbXYFzKZSHaPsEJJDJV8dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.1",
         "semver": "^7.6.0"
       },
       "engines": {
@@ -317,35 +324,35 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.5.0.tgz",
-      "integrity": "sha512-cAAQwJcRtiBxQWO0eprrAbOurtJz8U6MgYqLz+p9kLElirzSCc0vGMcyCaA1O7AqBuxo11l1XsY3FhOFowLAAg==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.1.tgz",
+      "integrity": "sha512-52PFbsl+1EvMuokZXLRlOsdcLHf10isTPlWwoY1FQIidTsTvjKXVXYb7AvtpWkDzRO2ZsqIgPK7bI98x8LRUEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^19.5.0",
-        "@commitlint/parse": "^19.5.0",
-        "@commitlint/rules": "^19.5.0",
-        "@commitlint/types": "^19.5.0"
+        "@commitlint/is-ignored": "^19.8.1",
+        "@commitlint/parse": "^19.8.1",
+        "@commitlint/rules": "^19.8.1",
+        "@commitlint/types": "^19.8.1"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.5.0.tgz",
-      "integrity": "sha512-INOUhkL/qaKqwcTUvCE8iIUf5XHsEPCLY9looJ/ipzi7jtGhgmtH7OOFiNvwYgH7mA8osUWOUDV8t4E2HAi4xA==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.1.tgz",
+      "integrity": "sha512-9V99EKG3u7z+FEoe4ikgq7YGRCSukAcvmKQuTtUyiYPnOd9a2/H9Ak1J9nJA1HChRQp9OA/sIKPugGS+FK/k1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^19.5.0",
-        "@commitlint/execute-rule": "^19.5.0",
-        "@commitlint/resolve-extends": "^19.5.0",
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/config-validator": "^19.8.1",
+        "@commitlint/execute-rule": "^19.8.1",
+        "@commitlint/resolve-extends": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
         "chalk": "^5.3.0",
         "cosmiconfig": "^9.0.0",
-        "cosmiconfig-typescript-loader": "^5.0.0",
+        "cosmiconfig-typescript-loader": "^6.1.0",
         "lodash.isplainobject": "^4.0.6",
         "lodash.merge": "^4.6.2",
         "lodash.uniq": "^4.5.0"
@@ -355,9 +362,9 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.5.0.tgz",
-      "integrity": "sha512-R7AM4YnbxN1Joj1tMfCyBryOC5aNJBdxadTZkuqtWi3Xj0kMdutq16XQwuoGbIzL2Pk62TALV1fZDCv36+JhTQ==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.1.tgz",
+      "integrity": "sha512-+PMLQvjRXiU+Ae0Wc+p99EoGEutzSXFVwQfa3jRNUZLNW5odZAyseb92OSBTKCu+9gGZiJASt76Cj3dLTtcTdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -365,13 +372,13 @@
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.5.0.tgz",
-      "integrity": "sha512-cZ/IxfAlfWYhAQV0TwcbdR1Oc0/r0Ik1GEessDJ3Lbuma/MRO8FRQX76eurcXtmhJC//rj52ZSZuXUg0oIX0Fw==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.1.tgz",
+      "integrity": "sha512-mmAHYcMBmAgJDKWdkjIGq50X4yB0pSGpxyOODwYmoexxxiUCy5JJT99t1+PEMK7KtsCtzuWYIAXYAiKR+k+/Jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/types": "^19.8.1",
         "conventional-changelog-angular": "^7.0.0",
         "conventional-commits-parser": "^5.0.0"
       },
@@ -380,31 +387,38 @@
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.5.0.tgz",
-      "integrity": "sha512-TjS3HLPsLsxFPQj6jou8/CZFAmOP2y+6V4PGYt3ihbQKTY1Jnv0QG28WRKl/d1ha6zLODPZqsxLEov52dhR9BQ==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.1.tgz",
+      "integrity": "sha512-03Jbjb1MqluaVXKHKRuGhcKWtSgh3Jizqy2lJCRbRrnWpcM06MYm8th59Xcns8EqBYvo0Xqb+2DoZFlga97uXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/top-level": "^19.5.0",
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/top-level": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
         "git-raw-commits": "^4.0.0",
         "minimist": "^1.2.8",
-        "tinyexec": "^0.3.0"
+        "tinyexec": "^1.0.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
+    "node_modules/@commitlint/read/node_modules/tinyexec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.5.0.tgz",
-      "integrity": "sha512-CU/GscZhCUsJwcKTJS9Ndh3AKGZTNFIOoQB2n8CmFnizE0VnEuJoum+COW+C1lNABEeqk6ssfc1Kkalm4bDklA==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.1.tgz",
+      "integrity": "sha512-GM0mAhFk49I+T/5UCYns5ayGStkTt4XFFrjjf0L4S26xoMTSkdCf9ZRO8en1kuopC4isDFuEm7ZOm/WRVeElVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^19.5.0",
-        "@commitlint/types": "^19.5.0",
+        "@commitlint/config-validator": "^19.8.1",
+        "@commitlint/types": "^19.8.1",
         "global-directory": "^4.0.1",
         "import-meta-resolve": "^4.0.0",
         "lodash.mergewith": "^4.6.2",
@@ -415,25 +429,25 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.5.0.tgz",
-      "integrity": "sha512-hDW5TPyf/h1/EufSHEKSp6Hs+YVsDMHazfJ2azIk9tHPXS6UqSz1dIRs1gpqS3eMXgtkT7JH6TW4IShdqOwhAw==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.1.tgz",
+      "integrity": "sha512-Hnlhd9DyvGiGwjfjfToMi1dsnw1EXKGJNLTcsuGORHz6SS9swRgkBsou33MQ2n51/boIDrbsg4tIBbRpEWK2kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^19.5.0",
-        "@commitlint/message": "^19.5.0",
-        "@commitlint/to-lines": "^19.5.0",
-        "@commitlint/types": "^19.5.0"
+        "@commitlint/ensure": "^19.8.1",
+        "@commitlint/message": "^19.8.1",
+        "@commitlint/to-lines": "^19.8.1",
+        "@commitlint/types": "^19.8.1"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.5.0.tgz",
-      "integrity": "sha512-R772oj3NHPkodOSRZ9bBVNq224DOxQtNef5Pl8l2M8ZnkkzQfeSTr4uxawV2Sd3ui05dUVzvLNnzenDBO1KBeQ==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.1.tgz",
+      "integrity": "sha512-98Mm5inzbWTKuZQr2aW4SReY6WUukdWXuZhrqf1QdKPZBCCsXuG87c+iP0bwtD6DBnmVVQjgp4whoHRVixyPBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -441,9 +455,9 @@
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.5.0.tgz",
-      "integrity": "sha512-IP1YLmGAk0yWrImPRRc578I3dDUI5A2UBJx9FbSOjxe9sTlzFiwVJ+zeMLgAtHMtGZsC8LUnzmW1qRemkFU4ng==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.1.tgz",
+      "integrity": "sha512-Ph8IN1IOHPSDhURCSXBz44+CIu+60duFwRsg6HqaISFHQHbmBtxVw4ZrFNIYUzEP7WwrNPxa2/5qJ//NK1FGcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -530,9 +544,9 @@
       }
     },
     "node_modules/@commitlint/top-level/node_modules/yocto-queue": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -543,9 +557,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.5.0.tgz",
-      "integrity": "sha512-DSHae2obMSMkAtTBSOulg5X7/z+rGLxcXQIkg3OmWvY6wifojge5uVMydfhUvs7yQj+V7jNmRZ2Xzl8GJyqRgg==",
+      "version": "19.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz",
+      "integrity": "sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1465,9 +1479,9 @@
       }
     },
     "node_modules/@types/conventional-commits-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
-      "integrity": "sha512-loB369iXNmAZglwWATL+WRe+CRMmmBPtpolYzIebFaX4YA3x+BEfLqhUAV9WanycKI3TG1IMr5bMJDajDKLlUQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.1.tgz",
+      "integrity": "sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1482,12 +1496,13 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.20.tgz",
-      "integrity": "sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -2342,20 +2357,21 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-5.0.0.tgz",
-      "integrity": "sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.1.0.tgz",
+      "integrity": "sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "jiti": "^1.19.1"
+        "jiti": "^2.4.1"
       },
       "engines": {
-        "node": ">=v16"
+        "node": ">=v18"
       },
       "peerDependencies": {
         "@types/node": "*",
-        "cosmiconfig": ">=8.2",
-        "typescript": ">=4"
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
       }
     },
     "node_modules/cross-spawn": {
@@ -3342,10 +3358,20 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
@@ -4572,12 +4598,13 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
-      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true,
+      "license": "MIT",
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-tokens": {
@@ -10064,10 +10091,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.0",
-        "commander": "12.1.0",
+        "commander": "14.0.0",
         "deep-keys": "0.5.0",
         "dotenv": "16.6.1",
         "fs-extra": "11.2.0",
-        "inquirer": "9.3.7",
+        "inquirer": "12.9.4",
         "lodash": "4.17.21",
         "replace": "1.2.2"
       },
@@ -687,13 +687,449 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.2.tgz",
+      "integrity": "sha512-E+KExNurKcUJJdxmjglTl141EwxWyAHplvsYJQgSwXf8qiNWkTxTuCCqmhFEmbIXd4zLaGMfQFJ6WrZ7fSeV3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/checkbox/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/checkbox/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.16.tgz",
+      "integrity": "sha512-j1a5VstaK5KQy8Mu8cHmuQvN1Zc62TbLhjJxwHvKPPKEoowSF6h/0UdOpA9DNdWZ+9Inq73+puRq1df6OJ8Sag==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.0.tgz",
+      "integrity": "sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.18.tgz",
+      "integrity": "sha512-yeQN3AXjCm7+Hmq5L6Dm2wEDeBRdAZuyZ4I7tWSSanbxDzqM0KqzoDbKM7p4ebllAYdoQuPJS6N71/3L281i6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/external-editor": "^1.0.1",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.18.tgz",
+      "integrity": "sha512-xUjteYtavH7HwDMzq4Cn2X4Qsh5NozoDHCJTdoXg9HfZ4w3R6mxV1B9tL7DGJX2eq/zqtsFjhm0/RJIMGlh3ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/type": "^3.0.8",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
+      "integrity": "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.3.tgz",
-      "integrity": "sha512-ErXXzENMH5pJt5/ssXV0DfWUZqly8nGzf0UcBV9xTnP+KyffE2mqyxIMBrZ8ijQck2nU0TQm40EQB53YreyWHw==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.2.tgz",
+      "integrity": "sha512-hqOvBZj/MhQCpHUuD3MVq18SSoDNHy7wEnQ8mtvs71K8OPZVXJinOzcvQna33dNYLYE4LkA9BlhAhK6MJcsVbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.18.tgz",
+      "integrity": "sha512-7exgBm52WXZRczsydCVftozFTrrwbG5ySE0GqUd2zLNSBXyIucs2Wnm7ZKLe/aUu6NUg9dg7Q80QIHCdZJiY4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.18.tgz",
+      "integrity": "sha512-zXvzAGxPQTNk/SbT3carAD4Iqi6A2JS2qtcqQjsL22uvD+JfQzUrDEtPjLL7PLn8zlSNyPdY02IiQjzoL9TStA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/password/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.4.tgz",
+      "integrity": "sha512-MuxVZ1en1g5oGamXV3DWP89GEkdD54alcfhHd7InUW5BifAdKQEK9SLFa/5hlWbvuhMPlobF0WAx7Okq988Jxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.2.2",
+        "@inquirer/confirm": "^5.1.16",
+        "@inquirer/editor": "^4.2.18",
+        "@inquirer/expand": "^4.0.18",
+        "@inquirer/input": "^4.2.2",
+        "@inquirer/number": "^3.0.18",
+        "@inquirer/password": "^4.0.18",
+        "@inquirer/rawlist": "^4.1.6",
+        "@inquirer/search": "^3.1.1",
+        "@inquirer/select": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.6.tgz",
+      "integrity": "sha512-KOZqa3QNr3f0pMnufzL7K+nweFFCCBs6LCXZzXDrVGTyssjLeudn5ySktZYv1XiSqobyHRYYK0c6QsOxJEhXKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/type": "^3.0.8",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.1.1.tgz",
+      "integrity": "sha512-TkMUY+A2p2EYVY3GCTItYGvqT6LiLzHBnqsU1rJbrpXUijFfM6zvUx0R4civofVwFCmJZcKqOVwwWAjplKkhxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.2.tgz",
+      "integrity": "sha512-nwous24r31M+WyDEHV+qckXkepvihxhnyIaod2MG7eCE6G0Zm/HUF6jgN8GXgf4U7AU6SLseKdanY195cwvU6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/select/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -763,18 +1199,37 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
-      "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@octokit/types": "^13.0.0",
+        "@octokit/types": "^14.0.0",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
       }
     },
     "node_modules/@octokit/graphql": {
@@ -835,16 +1290,17 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.1.tgz",
-      "integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@octokit/endpoint": "^10.0.0",
-        "@octokit/request-error": "^6.0.1",
-        "@octokit/types": "^13.1.0",
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^2.0.0",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
@@ -852,18 +1308,74 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
-      "integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@octokit/types": "^13.0.0"
+        "@octokit/types": "^14.0.0"
       },
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@octokit/types": {
       "version": "13.5.0",
@@ -1652,7 +2164,7 @@
       "version": "24.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
       "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
@@ -1974,25 +2486,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/before-after-hook": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
@@ -2001,29 +2494,6 @@
       "license": "Apache-2.0",
       "peer": true
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
@@ -2031,9 +2501,10 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2050,29 +2521,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/call-bind": {
@@ -2134,9 +2582,10 @@
       }
     },
     "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+      "license": "MIT"
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -2145,17 +2594,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/cli-highlight": {
@@ -2241,17 +2679,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-table3": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
@@ -2272,6 +2699,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
       "engines": {
         "node": ">= 12"
       }
@@ -2307,14 +2735,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2329,12 +2749,12 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/compare-func": {
@@ -2619,17 +3039,6 @@
       "integrity": "sha512-/80a4+9lbLj1hRxG0ULtEOGtbM4hN/5u1Vu6kc6ZkYePUq+ZhtboRIsWTVKplc2ET1xY2FMVwhyt46w9vPf9Rg==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-data-property": {
@@ -3452,19 +3861,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/fast-content-type-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
@@ -4036,6 +4432,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4199,34 +4596,16 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/ignore": {
       "version": "5.3.1",
@@ -4330,7 +4709,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -4339,26 +4719,29 @@
       "dev": true
     },
     "node_modules/inquirer": {
-      "version": "9.3.7",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.7.tgz",
-      "integrity": "sha512-LJKFHCSeIRq9hanN14IlOtPSTe3lNES7TYDTE2xxdAy1LS5rYphajK1qtwvj3YmQXvvk0U2Vbmcni8P9EIQW9w==",
+      "version": "12.9.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.4.tgz",
+      "integrity": "sha512-5bV3LOgLtMAiJq1QpaUddfRrvaX59wiMYppS7z2jNRSQ64acI0yqx7WMxWhgymenSXOyD657g9tlsTjqGYM8sg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.3",
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/prompts": "^7.8.4",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
-        "cli-width": "^4.1.0",
-        "external-editor": "^3.1.0",
-        "mute-stream": "1.0.0",
-        "ora": "^5.4.1",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
+        "mute-stream": "^2.0.0",
+        "run-async": "^4.0.5",
+        "rxjs": "^7.8.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/inquirer/node_modules/ansi-escapes": {
@@ -4534,14 +4917,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-interactive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-negative-zero": {
@@ -5051,47 +5426,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/log-symbols/node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5212,6 +5546,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5253,11 +5588,12 @@
       "dev": true
     },
     "node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/mz": {
@@ -8150,6 +8486,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -8175,62 +8512,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ora/node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/p-each-series": {
@@ -9072,18 +9353,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -9110,9 +9379,10 @@
       }
     },
     "node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -9141,9 +9411,10 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9175,7 +9446,8 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -9197,7 +9469,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/semantic-release": {
       "version": "24.2.7",
@@ -9628,7 +9901,8 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/signale": {
       "version": "1.4.0",
@@ -9811,6 +10085,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -9935,6 +10210,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -10108,17 +10384,6 @@
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -10307,7 +10572,7 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
@@ -10383,7 +10648,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -10394,14 +10660,6 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dependencies": {
-        "defaults": "^1.0.3"
       }
     },
     "node_modules/which": {
@@ -10570,9 +10828,9 @@
       }
     },
     "node_modules/yoctocolors-cjs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
-      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generate-react-cli",
-  "version": "8.4.8",
+  "version": "8.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generate-react-cli",
-      "version": "8.4.8",
+      "version": "8.4.9",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.3.0",
@@ -35,7 +35,7 @@
         "eslint-plugin-prettier": "5.2.1",
         "husky": "9.1.6",
         "prettier": "3.3.3",
-        "pretty-quick": "4.0.0",
+        "pretty-quick": "4.2.2",
         "semantic-release": "24.2.0"
       },
       "engines": {
@@ -8663,10 +8663,11 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -8823,18 +8824,19 @@
       }
     },
     "node_modules/pretty-quick": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-4.0.0.tgz",
-      "integrity": "sha512-M+2MmeufXb/M7Xw3Afh1gxcYpj+sK0AxEfnfF958ktFeAyi5MsKY5brymVURQLgPLV1QaF5P4pb2oFJ54H3yzQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-4.2.2.tgz",
+      "integrity": "sha512-uAh96tBW1SsD34VhhDmWuEmqbpfYc/B3j++5MC/6b3Cb8Ow7NJsvKFhg0eoGu2xXX+o9RkahkTK6sUdd8E7g5w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "execa": "^5.1.1",
-        "find-up": "^5.0.0",
-        "ignore": "^5.3.0",
+        "@pkgr/core": "^0.2.7",
+        "ignore": "^7.0.5",
         "mri": "^1.2.0",
-        "picocolors": "^1.0.0",
-        "picomatch": "^3.0.1",
-        "tslib": "^2.6.2"
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.2",
+        "tinyexec": "^0.3.2",
+        "tslib": "^2.8.1"
       },
       "bin": {
         "pretty-quick": "lib/cli.mjs"
@@ -8842,17 +8844,44 @@
       "engines": {
         "node": ">=14"
       },
+      "funding": {
+        "url": "https://opencollective.com/pretty-quick"
+      },
       "peerDependencies": {
         "prettier": "^3.0.0"
       }
     },
-    "node_modules/pretty-quick/node_modules/picomatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-      "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+    "node_modules/pretty-quick/node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/pretty-quick/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/pretty-quick/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -10297,9 +10326,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
-      "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -10353,9 +10382,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "chalk": "5.3.0",
         "commander": "12.1.0",
         "deep-keys": "0.5.0",
-        "dotenv": "16.4.5",
+        "dotenv": "16.6.1",
         "fs-extra": "11.2.0",
         "inquirer": "9.3.7",
         "lodash": "4.17.21",
@@ -2540,9 +2540,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "5.2.1",
-        "husky": "9.1.6",
+        "husky": "9.1.7",
         "prettier": "3.3.3",
         "pretty-quick": "4.2.2",
         "semantic-release": "24.2.0"
@@ -3977,9 +3977,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
-      "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint": "8.57.1",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-config-prettier": "9.1.0",
-        "eslint-plugin-prettier": "5.2.1",
+        "eslint-plugin-prettier": "5.5.4",
         "husky": "9.1.7",
         "prettier": "3.6.2",
         "pretty-quick": "4.2.2",
@@ -872,15 +872,16 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
-      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://opencollective.com/unts"
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -3094,14 +3095,14 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
-      "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
+      "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.9.1"
+        "synckit": "^0.11.7"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -3112,7 +3113,7 @@
       "peerDependencies": {
         "@types/eslint": ">=8.0.0",
         "eslint": ">=8.0.0",
-        "eslint-config-prettier": "*",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
         "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
@@ -8401,19 +8402,6 @@
         "prettier": "^3.0.0"
       }
     },
-    "node_modules/pretty-quick/node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pkgr"
-      }
-    },
     "node_modules/pretty-quick/node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -9745,20 +9733,19 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
-      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.1.0",
-        "tslib": "^2.6.2"
+        "@pkgr/core": "^0.2.9"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
-        "url": "https://opencollective.com/unts"
+        "url": "https://opencollective.com/synckit"
       }
     },
     "node_modules/temp-dir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.4.9",
       "license": "MIT",
       "dependencies": {
-        "chalk": "5.3.0",
+        "chalk": "5.6.0",
         "commander": "12.1.0",
         "deep-keys": "0.5.0",
         "dotenv": "16.6.1",
@@ -1953,9 +1953,10 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
+      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "fs-extra": "11.2.0",
         "inquirer": "9.3.7",
         "lodash": "4.17.21",
+        "npm": "^10.9.3",
         "replace": "1.2.2"
       },
       "bin": {
@@ -5109,9 +5110,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.0.tgz",
-      "integrity": "sha512-ZanDioFylI9helNhl2LNd+ErmVD+H5I53ry41ixlLyCBgkuYb+58CvbAp99hW+zr5L9W4X7CchSoeqKdngOLSw==",
+      "version": "10.9.3",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.3.tgz",
+      "integrity": "sha512-6Eh1u5Q+kIVXeA8e7l2c/HpnFFcwrkt37xDMujD5be1gloWa9p6j3Fsv3mByXXmqJHy+2cElRMML8opNT7xIJQ==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -5182,7 +5183,6 @@
         "which",
         "write-file-atomic"
       ],
-      "dev": true,
       "license": "Artistic-2.0",
       "workspaces": [
         "docs",
@@ -5193,63 +5193,63 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^8.0.0",
+        "@npmcli/arborist": "^8.0.1",
         "@npmcli/config": "^9.0.0",
         "@npmcli/fs": "^4.0.0",
-        "@npmcli/map-workspaces": "^4.0.1",
-        "@npmcli/package-json": "^6.0.1",
-        "@npmcli/promise-spawn": "^8.0.1",
-        "@npmcli/redact": "^3.0.0",
-        "@npmcli/run-script": "^9.0.1",
-        "@sigstore/tuf": "^2.3.4",
-        "abbrev": "^3.0.0",
+        "@npmcli/map-workspaces": "^4.0.2",
+        "@npmcli/package-json": "^6.2.0",
+        "@npmcli/promise-spawn": "^8.0.2",
+        "@npmcli/redact": "^3.2.2",
+        "@npmcli/run-script": "^9.1.0",
+        "@sigstore/tuf": "^3.1.1",
+        "abbrev": "^3.0.1",
         "archy": "~1.0.0",
         "cacache": "^19.0.1",
-        "chalk": "^5.3.0",
-        "ci-info": "^4.0.0",
+        "chalk": "^5.4.1",
+        "ci-info": "^4.2.0",
         "cli-columns": "^4.0.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
         "glob": "^10.4.5",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^8.0.0",
+        "hosted-git-info": "^8.1.0",
         "ini": "^5.0.0",
-        "init-package-json": "^7.0.1",
-        "is-cidr": "^5.1.0",
+        "init-package-json": "^7.0.2",
+        "is-cidr": "^5.1.1",
         "json-parse-even-better-errors": "^4.0.0",
         "libnpmaccess": "^9.0.0",
-        "libnpmdiff": "^7.0.0",
-        "libnpmexec": "^9.0.0",
-        "libnpmfund": "^6.0.0",
+        "libnpmdiff": "^7.0.1",
+        "libnpmexec": "^9.0.1",
+        "libnpmfund": "^6.0.1",
         "libnpmhook": "^11.0.0",
         "libnpmorg": "^7.0.0",
-        "libnpmpack": "^8.0.0",
-        "libnpmpublish": "^10.0.0",
+        "libnpmpack": "^8.0.1",
+        "libnpmpublish": "^10.0.1",
         "libnpmsearch": "^8.0.0",
         "libnpmteam": "^7.0.0",
         "libnpmversion": "^7.0.0",
-        "make-fetch-happen": "^14.0.1",
+        "make-fetch-happen": "^14.0.3",
         "minimatch": "^9.0.5",
         "minipass": "^7.1.1",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^10.2.0",
-        "nopt": "^8.0.0",
+        "node-gyp": "^11.2.0",
+        "nopt": "^8.1.0",
         "normalize-package-data": "^7.0.0",
         "npm-audit-report": "^6.0.0",
-        "npm-install-checks": "^7.1.0",
-        "npm-package-arg": "^12.0.0",
+        "npm-install-checks": "^7.1.1",
+        "npm-package-arg": "^12.0.2",
         "npm-pick-manifest": "^10.0.0",
         "npm-profile": "^11.0.1",
-        "npm-registry-fetch": "^18.0.1",
+        "npm-registry-fetch": "^18.0.2",
         "npm-user-validate": "^3.0.0",
-        "p-map": "^4.0.0",
-        "pacote": "^19.0.0",
+        "p-map": "^7.0.3",
+        "pacote": "^19.0.1",
         "parse-conflict-json": "^4.0.0",
         "proc-log": "^5.0.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^4.0.0",
-        "semver": "^7.6.3",
+        "read": "^4.1.0",
+        "semver": "^7.7.2",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^12.0.0",
         "supports-color": "^9.4.0",
@@ -5257,7 +5257,7 @@
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^6.0.0",
+        "validate-npm-package-name": "^6.0.1",
         "which": "^5.0.0",
         "write-file-atomic": "^6.0.0"
       },
@@ -5283,7 +5283,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5299,8 +5298,7 @@
       }
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "dev": true,
+      "version": "6.1.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5312,13 +5310,11 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5335,7 +5331,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5350,7 +5345,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5362,13 +5356,11 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5383,8 +5375,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "8.0.0",
-      "dev": true,
+      "version": "8.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5433,7 +5424,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "9.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5452,7 +5442,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5463,8 +5452,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "6.0.1",
-      "dev": true,
+      "version": "6.0.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5473,7 +5461,6 @@
         "lru-cache": "^10.0.1",
         "npm-pick-manifest": "^10.0.0",
         "proc-log": "^5.0.0",
-        "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
         "which": "^5.0.0"
@@ -5484,7 +5471,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5499,8 +5485,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "4.0.1",
-      "dev": true,
+      "version": "4.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5514,14 +5499,13 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "8.0.0",
-      "dev": true,
+      "version": "8.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "cacache": "^19.0.0",
         "json-parse-even-better-errors": "^4.0.0",
-        "pacote": "^19.0.0",
+        "pacote": "^20.0.0",
         "proc-log": "^5.0.0",
         "semver": "^7.3.5"
       },
@@ -5529,9 +5513,38 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
+      "version": "20.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^6.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "@npmcli/run-script": "^9.0.0",
+        "cacache": "^19.0.0",
+        "fs-minipass": "^3.0.0",
+        "minipass": "^7.0.2",
+        "npm-package-arg": "^12.0.0",
+        "npm-packlist": "^9.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-registry-fetch": "^18.0.0",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1",
+        "sigstore": "^3.0.0",
+        "ssri": "^12.0.0",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "pacote": "bin/index.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5540,7 +5553,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5548,8 +5560,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "6.0.1",
-      "dev": true,
+      "version": "6.2.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5557,17 +5568,16 @@
         "glob": "^10.2.2",
         "hosted-git-info": "^8.0.0",
         "json-parse-even-better-errors": "^4.0.0",
-        "normalize-package-data": "^7.0.0",
         "proc-log": "^5.0.0",
-        "semver": "^7.5.3"
+        "semver": "^7.5.3",
+        "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "8.0.1",
-      "dev": true,
+      "version": "8.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5578,20 +5588,18 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "4.0.0",
-      "dev": true,
+      "version": "4.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "postcss-selector-parser": "^6.1.2"
+        "postcss-selector-parser": "^7.0.0"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
-      "version": "3.0.0",
-      "dev": true,
+      "version": "3.2.2",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5599,15 +5607,14 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "9.0.1",
-      "dev": true,
+      "version": "9.1.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/node-gyp": "^4.0.0",
         "@npmcli/package-json": "^6.0.0",
         "@npmcli/promise-spawn": "^8.0.0",
-        "node-gyp": "^10.0.0",
+        "node-gyp": "^11.0.0",
         "proc-log": "^5.0.0",
         "which": "^5.0.0"
       },
@@ -5617,7 +5624,6 @@
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -5625,241 +5631,36 @@
         "node": ">=14"
       }
     },
-    "node_modules/npm/node_modules/@sigstore/bundle": {
-      "version": "2.3.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.3.2"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.3.2",
-      "dev": true,
+      "version": "0.4.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "2.3.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^2.3.2",
-        "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.3.2",
-        "make-fetch-happen": "^13.0.1",
-        "proc-log": "^4.2.0",
-        "promise-retry": "^2.0.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/@npmcli/agent": {
-      "version": "2.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/@npmcli/fs": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/cacache": {
-      "version": "18.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^3.1.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^2.0.1",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^4.0.0",
-        "ssri": "^10.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^3.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/make-fetch-happen": {
-      "version": "13.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^2.0.0",
-        "cacache": "^18.0.0",
-        "http-cache-semantics": "^4.1.1",
-        "is-lambda": "^1.0.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^3.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "proc-log": "^4.2.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^10.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/minipass-fetch": {
-      "version": "3.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/proc-log": {
-      "version": "4.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/ssri": {
-      "version": "10.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/unique-filename": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign/node_modules/unique-slug": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "2.3.4",
-      "dev": true,
+      "version": "3.1.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.3.2",
-        "tuf-js": "^2.2.1"
+        "@sigstore/protobuf-specs": "^0.4.1",
+        "tuf-js": "^3.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "1.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^2.3.2",
-        "@sigstore/core": "^1.1.0",
-        "@sigstore/protobuf-specs": "^0.3.2"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.4"
-      },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/abbrev": {
-      "version": "3.0.0",
-      "dev": true,
+      "version": "3.0.1",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5867,33 +5668,15 @@
       }
     },
     "node_modules/npm/node_modules/agent-base": {
-      "version": "7.1.1",
-      "dev": true,
+      "version": "7.1.3",
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
       "engines": {
         "node": ">= 14"
       }
     },
-    "node_modules/npm/node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5902,7 +5685,6 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5914,25 +5696,21 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5948,7 +5726,6 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5959,8 +5736,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
+      "version": "2.0.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5969,7 +5745,6 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "19.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5992,29 +5767,14 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/chownr": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/npm/node_modules/cacache/node_modules/minizlib": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -6027,21 +5787,8 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/cacache/node_modules/p-map": {
-      "version": "7.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/npm/node_modules/cacache/node_modules/tar": {
       "version": "7.4.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6058,7 +5805,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/yallist": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -6066,8 +5812,7 @@
       }
     },
     "node_modules/npm/node_modules/chalk": {
-      "version": "5.3.0",
-      "dev": true,
+      "version": "5.4.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6079,7 +5824,6 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6087,8 +5831,7 @@
       }
     },
     "node_modules/npm/node_modules/ci-info": {
-      "version": "4.0.0",
-      "dev": true,
+      "version": "4.2.0",
       "funding": [
         {
           "type": "github",
@@ -6102,8 +5845,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "4.1.1",
-      "dev": true,
+      "version": "4.1.3",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6113,18 +5855,8 @@
         "node": ">=14"
       }
     },
-    "node_modules/npm/node_modules/clean-stack": {
-      "version": "2.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6137,7 +5869,6 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6146,7 +5877,6 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6158,19 +5888,16 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "dev": true,
+      "version": "7.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6184,7 +5911,6 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6199,7 +5925,6 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -6210,12 +5935,11 @@
       }
     },
     "node_modules/npm/node_modules/debug": {
-      "version": "4.3.6",
-      "dev": true,
+      "version": "4.4.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -6226,15 +5950,8 @@
         }
       }
     },
-    "node_modules/npm/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/diff": {
       "version": "5.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -6243,19 +5960,16 @@
     },
     "node_modules/npm/node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -6265,7 +5979,6 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6274,19 +5987,16 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
-      "version": "3.1.1",
-      "dev": true,
+      "version": "3.1.2",
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6294,12 +6004,11 @@
       }
     },
     "node_modules/npm/node_modules/foreground-child": {
-      "version": "3.3.0",
-      "dev": true,
+      "version": "3.3.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -6311,7 +6020,6 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6323,7 +6031,6 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "10.4.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6343,13 +6050,11 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "8.0.0",
-      "dev": true,
+      "version": "8.1.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6360,14 +6065,12 @@
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "dev": true,
+      "version": "4.2.0",
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6379,12 +6082,11 @@
       }
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "dev": true,
+      "version": "7.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -6393,7 +6095,6 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -6406,7 +6107,6 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6418,25 +6118,14 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
     },
-    "node_modules/npm/node_modules/indent-string": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/ini": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6444,8 +6133,7 @@
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "7.0.1",
-      "dev": true,
+      "version": "7.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6463,7 +6151,6 @@
     },
     "node_modules/npm/node_modules/ip-address": {
       "version": "9.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6476,7 +6163,6 @@
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6487,8 +6173,7 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "5.1.0",
-      "dev": true,
+      "version": "5.1.1",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6500,28 +6185,19 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/is-lambda": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "3.4.3",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6536,13 +6212,11 @@
     },
     "node_modules/npm/node_modules/jsbn": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6551,7 +6225,6 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -6560,7 +6233,6 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -6569,19 +6241,16 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "9.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6593,12 +6262,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "7.0.0",
-      "dev": true,
+      "version": "7.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.0",
+        "@npmcli/arborist": "^8.0.1",
         "@npmcli/installed-package-contents": "^3.0.0",
         "binary-extensions": "^2.3.0",
         "diff": "^5.1.0",
@@ -6612,12 +6280,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "9.0.0",
-      "dev": true,
+      "version": "9.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.0",
+        "@npmcli/arborist": "^8.0.1",
         "@npmcli/run-script": "^9.0.1",
         "ci-info": "^4.0.0",
         "npm-package-arg": "^12.0.0",
@@ -6633,12 +6300,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "6.0.0",
-      "dev": true,
+      "version": "6.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.0"
+        "@npmcli/arborist": "^8.0.1"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -6646,7 +6312,6 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "11.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6659,7 +6324,6 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6671,12 +6335,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "8.0.0",
-      "dev": true,
+      "version": "8.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^8.0.0",
+        "@npmcli/arborist": "^8.0.1",
         "@npmcli/run-script": "^9.0.1",
         "npm-package-arg": "^12.0.0",
         "pacote": "^19.0.0"
@@ -6686,8 +6349,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "10.0.0",
-      "dev": true,
+      "version": "10.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6697,7 +6359,7 @@
         "npm-registry-fetch": "^18.0.1",
         "proc-log": "^5.0.0",
         "semver": "^7.3.7",
-        "sigstore": "^2.2.0",
+        "sigstore": "^3.0.0",
         "ssri": "^12.0.0"
       },
       "engines": {
@@ -6706,7 +6368,6 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6718,7 +6379,6 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6731,7 +6391,6 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6747,13 +6406,11 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "10.4.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "14.0.1",
-      "dev": true,
+      "version": "14.0.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6764,7 +6421,7 @@
         "minipass-fetch": "^4.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
+        "negotiator": "^1.0.0",
         "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1",
         "ssri": "^12.0.0"
@@ -6773,9 +6430,16 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/npm/node_modules/minimatch": {
       "version": "9.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6790,7 +6454,6 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "7.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6799,7 +6462,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6810,8 +6472,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "4.0.0",
-      "dev": true,
+      "version": "4.0.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6826,22 +6487,8 @@
         "encoding": "^0.1.13"
       }
     },
-    "node_modules/npm/node_modules/minipass-fetch/node_modules/minizlib": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6853,7 +6500,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6865,7 +6511,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6877,7 +6522,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6889,7 +6533,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6901,7 +6544,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6912,33 +6554,18 @@
       }
     },
     "node_modules/npm/node_modules/minizlib": {
-      "version": "2.1.2",
-      "dev": true,
+      "version": "3.0.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">= 18"
       }
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -6950,243 +6577,92 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/negotiator": {
-      "version": "0.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "10.2.0",
-      "dev": true,
+      "version": "11.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
-        "glob": "^10.3.10",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^13.0.0",
-        "nopt": "^7.0.0",
-        "proc-log": "^4.1.0",
+        "make-fetch-happen": "^14.0.3",
+        "nopt": "^8.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.5",
-        "tar": "^6.2.1",
-        "which": "^4.0.0"
+        "tar": "^7.4.3",
+        "tinyglobby": "^0.2.12",
+        "which": "^5.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/agent": {
-      "version": "2.2.2",
-      "dev": true,
+    "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
+      "version": "3.0.0",
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": ">=18"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/fs": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
-      "version": "18.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^3.1.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^2.0.1",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^4.0.0",
-        "ssri": "^10.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^3.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/isexe": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
-      "version": "13.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^2.0.0",
-        "cacache": "^18.0.0",
-        "http-cache-semantics": "^4.1.1",
-        "is-lambda": "^1.0.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^3.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "proc-log": "^4.2.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^10.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/minipass-fetch": {
-      "version": "3.0.5",
-      "dev": true,
+    "node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
+      "version": "3.0.1",
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
-      "version": "7.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^2.0.0"
-      },
       "bin": {
-        "nopt": "bin/nopt.js"
+        "mkdirp": "dist/cjs/src/bin.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/proc-log": {
-      "version": "4.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/ssri": {
-      "version": "10.0.6",
-      "dev": true,
+    "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
+      "version": "7.4.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^7.0.3"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">=18"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/unique-filename": {
-      "version": "3.0.0",
-      "dev": true,
+    "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
+      "version": "5.0.0",
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^4.0.0"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/unique-slug": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/which": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/npm/node_modules/nopt": {
-      "version": "8.0.0",
-      "dev": true,
+      "version": "8.1.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^2.0.0"
+        "abbrev": "^3.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
@@ -7195,18 +6671,8 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/nopt/node_modules/abbrev": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -7220,7 +6686,6 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7229,7 +6694,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7240,8 +6704,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "7.1.0",
-      "dev": true,
+      "version": "7.1.1",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -7253,7 +6716,6 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7261,8 +6723,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "12.0.0",
-      "dev": true,
+      "version": "12.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7277,7 +6738,6 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "9.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7289,7 +6749,6 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "10.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7304,7 +6763,6 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "11.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7316,8 +6774,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "18.0.1",
-      "dev": true,
+      "version": "18.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7334,22 +6791,8 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/npm-registry-fetch/node_modules/minizlib": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.0.4",
-        "rimraf": "^5.0.5"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -7357,29 +6800,23 @@
       }
     },
     "node_modules/npm/node_modules/p-map": {
-      "version": "4.0.0",
-      "dev": true,
+      "version": "7.0.3",
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/package-json-from-dist": {
-      "version": "1.0.0",
-      "dev": true,
+      "version": "1.0.1",
       "inBundle": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "19.0.0",
-      "dev": true,
+      "version": "19.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7397,7 +6834,7 @@
         "npm-registry-fetch": "^18.0.0",
         "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1",
-        "sigstore": "^2.2.0",
+        "sigstore": "^3.0.0",
         "ssri": "^12.0.0",
         "tar": "^6.1.11"
       },
@@ -7410,7 +6847,6 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7424,7 +6860,6 @@
     },
     "node_modules/npm/node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7433,7 +6868,6 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "1.11.1",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -7448,8 +6882,7 @@
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "dev": true,
+      "version": "7.1.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7462,7 +6895,6 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7471,7 +6903,6 @@
     },
     "node_modules/npm/node_modules/proggy": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7480,7 +6911,6 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -7488,23 +6918,15 @@
       }
     },
     "node_modules/npm/node_modules/promise-call-limit": {
-      "version": "3.0.1",
-      "dev": true,
+      "version": "3.0.2",
       "inBundle": true,
       "license": "ISC",
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7517,7 +6939,6 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7529,15 +6950,13 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "dev": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "4.0.0",
-      "dev": true,
+      "version": "4.1.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7549,7 +6968,6 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7558,7 +6976,6 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7571,38 +6988,20 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
-    "node_modules/npm/node_modules/rimraf": {
-      "version": "5.0.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.6.3",
-      "dev": true,
+      "version": "7.7.2",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -7614,7 +7013,6 @@
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7626,7 +7024,6 @@
     },
     "node_modules/npm/node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7635,7 +7032,6 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7646,25 +7042,71 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "2.3.1",
-      "dev": true,
+      "version": "3.1.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.3.2",
-        "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.3.2",
-        "@sigstore/sign": "^2.3.2",
-        "@sigstore/tuf": "^2.3.4",
-        "@sigstore/verify": "^1.2.1"
+        "@sigstore/bundle": "^3.1.0",
+        "@sigstore/core": "^2.0.0",
+        "@sigstore/protobuf-specs": "^0.4.0",
+        "@sigstore/sign": "^3.1.0",
+        "@sigstore/tuf": "^3.1.0",
+        "@sigstore/verify": "^2.1.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.4.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^3.1.0",
+        "@sigstore/core": "^2.0.0",
+        "@sigstore/protobuf-specs": "^0.4.0",
+        "make-fetch-happen": "^14.0.2",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^3.1.0",
+        "@sigstore/core": "^2.0.0",
+        "@sigstore/protobuf-specs": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7673,8 +7115,7 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.3",
-      "dev": true,
+      "version": "2.8.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7687,12 +7128,11 @@
       }
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "8.0.4",
-      "dev": true,
+      "version": "8.0.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.1",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "socks": "^2.8.3"
       },
@@ -7702,7 +7142,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7712,7 +7151,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7722,13 +7160,11 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7737,20 +7173,17 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.18",
-      "dev": true,
+      "version": "3.0.21",
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/sprintf-js": {
       "version": "1.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "12.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7762,7 +7195,6 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7777,7 +7209,6 @@
     "node_modules/npm/node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7791,7 +7222,6 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7804,7 +7234,6 @@
     "node_modules/npm/node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7816,7 +7245,6 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "9.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7828,7 +7256,6 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7845,7 +7272,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7857,7 +7283,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7869,28 +7294,86 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/tar/node_modules/minizlib": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/npm/node_modules/tar/node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/npm/node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.6",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7898,158 +7381,32 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "2.2.1",
-      "dev": true,
+      "version": "3.0.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "2.0.1",
-        "debug": "^4.3.4",
-        "make-fetch-happen": "^13.0.1"
+        "@tufjs/models": "3.0.1",
+        "debug": "^4.3.6",
+        "make-fetch-happen": "^14.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/tuf-js/node_modules/@npmcli/agent": {
-      "version": "2.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/tuf-js/node_modules/@npmcli/fs": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/tuf-js/node_modules/cacache": {
-      "version": "18.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^3.1.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^2.0.1",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^4.0.0",
-        "ssri": "^10.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^3.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/tuf-js/node_modules/make-fetch-happen": {
-      "version": "13.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^2.0.0",
-        "cacache": "^18.0.0",
-        "http-cache-semantics": "^4.1.1",
-        "is-lambda": "^1.0.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^3.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "proc-log": "^4.2.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^10.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/tuf-js/node_modules/minipass-fetch": {
-      "version": "3.0.5",
-      "dev": true,
+    "node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
+      "version": "3.0.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^9.0.5"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/npm/node_modules/tuf-js/node_modules/proc-log": {
-      "version": "4.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/tuf-js/node_modules/ssri": {
-      "version": "10.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/tuf-js/node_modules/unique-filename": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/tuf-js/node_modules/unique-slug": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8061,7 +7418,6 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8073,13 +7429,11 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8089,7 +7443,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8098,8 +7451,7 @@
       }
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "6.0.0",
-      "dev": true,
+      "version": "6.0.1",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -8108,13 +7460,11 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/which": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8129,7 +7479,6 @@
     },
     "node_modules/npm/node_modules/which/node_modules/isexe": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -8138,7 +7487,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8156,7 +7504,6 @@
     "node_modules/npm/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8173,7 +7520,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8187,8 +7533,7 @@
       }
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "dev": true,
+      "version": "6.1.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -8200,13 +7545,11 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8223,7 +7566,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -8238,7 +7580,6 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8251,7 +7592,6 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,11 +24,11 @@
       "devDependencies": {
         "@commitlint/cli": "19.8.1",
         "@commitlint/config-conventional": "19.8.1",
-        "@semantic-release/commit-analyzer": "13.0.0",
+        "@semantic-release/commit-analyzer": "13.0.1",
         "@semantic-release/git": "10.0.1",
-        "@semantic-release/github": "11.0.0",
-        "@semantic-release/npm": "12.0.1",
-        "@semantic-release/release-notes-generator": "14.0.1",
+        "@semantic-release/github": "11.0.5",
+        "@semantic-release/npm": "12.0.2",
+        "@semantic-release/release-notes-generator": "14.0.3",
         "eslint": "8.57.1",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-config-prettier": "9.1.0",
@@ -36,7 +36,7 @@
         "husky": "9.1.7",
         "prettier": "3.6.2",
         "pretty-quick": "4.2.2",
-        "semantic-release": "24.2.0"
+        "semantic-release": "24.2.7"
       },
       "engines": {
         "node": ">=10.x",
@@ -205,6 +205,7 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
@@ -736,6 +737,7 @@
       "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -746,6 +748,7 @@
       "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.0.0",
@@ -765,6 +768,7 @@
       "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^13.0.0",
         "universal-user-agent": "^7.0.2"
@@ -779,6 +783,7 @@
       "integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/request": "^9.0.0",
         "@octokit/types": "^13.0.0",
@@ -793,57 +798,40 @@
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
       "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.0.tgz",
-      "integrity": "sha512-n4znWfRinnUQF6TPyxs7EctSAA3yVSP4qlJP2YgI3g9d4Ae2n5F3XDOjbUluKRxPU3rfsgpOboI4O4VtPc6Ilg==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.1.1.tgz",
+      "integrity": "sha512-q9iQGlZlxAVNRN2jDNskJW/Cafy7/XE52wjZ5TTvyhyOD904Cvx//DNyoO3J/MXJ0ve3rPoNWKEg5iZrisQSuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.5.0"
+        "@octokit/types": "^14.1.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       },
       "peerDependencies": {
         "@octokit/core": ">=6"
       }
     },
-    "node_modules/@octokit/plugin-retry": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.1.1.tgz",
-      "integrity": "sha512-G9Ue+x2odcb8E1XIPhaFBnTTIrrUDfXN05iFXiqhR+SeeeDMMILcAnysOsxUpEWcQp2e5Ft397FCXTcPkiPkLw==",
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/request-error": "^6.0.0",
-        "@octokit/types": "^13.0.0",
-        "bottleneck": "^2.15.3"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
+      "license": "MIT"
     },
-    "node_modules/@octokit/plugin-throttling": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.3.0.tgz",
-      "integrity": "sha512-B5YTToSRTzNSeEyssnrT7WwGhpIdbpV9NKIs3KyTWHX6PhpYn7gqF/+lL3BvsASBM3Sg5BAUYk7KZx5p/Ec77w==",
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.0.0",
-        "bottleneck": "^2.15.3"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "^6.0.0"
+        "@octokit/openapi-types": "^25.1.0"
       }
     },
     "node_modules/@octokit/request": {
@@ -852,6 +840,7 @@
       "integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/endpoint": "^10.0.0",
         "@octokit/request-error": "^6.0.1",
@@ -868,6 +857,7 @@
       "integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/types": "^13.0.0"
       },
@@ -881,6 +871,7 @@
       "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^22.2.0"
       }
@@ -947,9 +938,9 @@
       "license": "MIT"
     },
     "node_modules/@semantic-release/commit-analyzer": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.0.tgz",
-      "integrity": "sha512-KtXWczvTAB1ZFZ6B4O+w8HkfYm/OgQb1dUGNFZtDgQ0csggrmkq8sTxhd+lwGF8kMb59/RnG9o4Tn7M/I8dQ9Q==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
+      "integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -958,7 +949,7 @@
         "conventional-commits-filter": "^5.0.0",
         "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
-        "import-from-esm": "^1.0.3",
+        "import-from-esm": "^2.0.0",
         "lodash-es": "^4.17.21",
         "micromatch": "^4.0.2"
       },
@@ -983,9 +974,9 @@
       }
     },
     "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-commits-parser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
-      "integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.0.tgz",
+      "integrity": "sha512-uLnoLeIW4XaoFtH37qEcg/SXMJmKF4vi7V0H2rnPueg+VEtFGA/asSCNTcq4M/GQ6QmlzchAEtOoDTtKqWeHag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1043,16 +1034,16 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-11.0.0.tgz",
-      "integrity": "sha512-Uon6G6gJD8U1JNvPm7X0j46yxNRJ8Ui6SgK4Zw5Ktu8RgjEft3BGn+l/RX1TTzhhO3/uUcKuqM+/9/ETFxWS/Q==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-11.0.5.tgz",
+      "integrity": "sha512-wJamzHteXwBdopvkTD6BJjPz1UHLm20twlVCSMA9zpd3B5KrOQX137jfTbNJT6ZVz3pXtg0S1DroQl4wifJ4WQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/core": "^6.0.0",
-        "@octokit/plugin-paginate-rest": "^11.0.0",
-        "@octokit/plugin-retry": "^7.0.0",
-        "@octokit/plugin-throttling": "^9.0.0",
+        "@octokit/core": "^7.0.0",
+        "@octokit/plugin-paginate-rest": "^13.0.0",
+        "@octokit/plugin-retry": "^8.0.0",
+        "@octokit/plugin-throttling": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
         "aggregate-error": "^5.0.0",
         "debug": "^4.3.4",
@@ -1071,6 +1062,146 @@
       },
       "peerDependencies": {
         "semantic-release": ">=24.1.0"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/core": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.3.tgz",
+      "integrity": "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.1",
+        "@octokit/request": "^10.0.2",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/endpoint": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.0.tgz",
+      "integrity": "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/graphql": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.1.tgz",
+      "integrity": "sha512-j1nQNU1ZxNFx2ZtKmL4sMrs4egy5h65OMDmSbVyuCzjOcwsHq6EaYjOTGXPQxgfiN8dJ4CriYHk6zF050WEULg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/plugin-retry": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.0.1.tgz",
+      "integrity": "sha512-KUoYR77BjF5O3zcwDQHRRZsUvJwepobeqiSSdCJ8lWt27FZExzb0GgVxrhhfuyF6z2B2zpO0hN5pteni1sqWiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=7"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/plugin-throttling": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.1.tgz",
+      "integrity": "sha512-S+EVhy52D/272L7up58dr3FNSMXWuNZolkL4zMJBNIfIxyZuUcczsQAU4b5w6dewJXnKYVgSHSV5wxitMSW1kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^7.0.0"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/request": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.3.tgz",
+      "integrity": "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.0",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/request-error": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.0.tgz",
+      "integrity": "sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
       }
     },
     "node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
@@ -1099,6 +1230,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@semantic-release/github/node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@semantic-release/github/node_modules/clean-stack": {
       "version": "5.2.0",
@@ -1143,9 +1281,9 @@
       }
     },
     "node_modules/@semantic-release/npm": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.1.tgz",
-      "integrity": "sha512-/6nntGSUGK2aTOI0rHPwY3ZjgY9FkXmEHbW9Kr+62NVOsyqpKKeP0lrCH+tphv+EsNdJNmqqwijTEnVWUMQ2Nw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.2.tgz",
+      "integrity": "sha512-+M9/Lb35IgnlUO6OSJ40Ie+hUsZLuph2fqXC/qrKn0fMvUU/jiCjpoL6zEm69vzcmaZJ8yNKtMBEKHWN49WBbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1156,7 +1294,7 @@
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^8.0.0",
-        "npm": "^10.5.0",
+        "npm": "^10.9.3",
         "rc": "^1.2.8",
         "read-pkg": "^9.0.0",
         "registry-auth-token": "^5.0.0",
@@ -1240,27 +1378,27 @@
       }
     },
     "node_modules/@semantic-release/npm/node_modules/execa": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.1.0.tgz",
-      "integrity": "sha512-lSgHc4Elo2m6bUDhc3Hl/VxvUDJdQWI40RZ4KMY9bKRc+hgMOT7II/JjbNDhI8VnMtrCb7U/fhpJIkLORZozWw==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
+      "integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.6",
         "figures": "^6.1.0",
         "get-stream": "^9.0.0",
-        "human-signals": "^7.0.0",
+        "human-signals": "^8.0.1",
         "is-plain-obj": "^4.1.0",
         "is-stream": "^4.0.1",
-        "npm-run-path": "^5.2.0",
-        "pretty-ms": "^9.0.0",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
         "signal-exit": "^4.1.0",
         "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.0.0"
+        "yoctocolors": "^2.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^18.19.0 || >=20.5.0"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
@@ -1284,9 +1422,9 @@
       }
     },
     "node_modules/@semantic-release/npm/node_modules/human-signals": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
-      "integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1320,16 +1458,17 @@
       }
     },
     "node_modules/@semantic-release/npm/node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "path-key": "^4.0.0"
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1374,10 +1513,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@semantic-release/npm/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@semantic-release/release-notes-generator": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.0.1.tgz",
-      "integrity": "sha512-K0w+5220TM4HZTthE5dDpIuFrnkN1NfTGPidJFm04ULT1DEZ9WG89VNXN7F0c+6nMEpWgqmPvb7vY7JkB2jyyA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.0.3.tgz",
+      "integrity": "sha512-XxAZRPWGwO5JwJtS83bRdoIhCiYIx8Vhr+u231pQAsdFIAbm19rSVJLdnBN+Avvk7CKvNQE/nJ4y7uqKH6WTiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1387,7 +1539,7 @@
         "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
         "get-stream": "^7.0.0",
-        "import-from-esm": "^1.0.3",
+        "import-from-esm": "^2.0.0",
         "into-stream": "^7.0.0",
         "lodash-es": "^4.17.21",
         "read-package-up": "^11.0.0"
@@ -1413,9 +1565,9 @@
       }
     },
     "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-parser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
-      "integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.0.tgz",
+      "integrity": "sha512-uLnoLeIW4XaoFtH37qEcg/SXMJmKF4vi7V0H2rnPueg+VEtFGA/asSCNTcq4M/GQ6QmlzchAEtOoDTtKqWeHag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1459,6 +1611,7 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1588,27 +1741,16 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
-      "integrity": "sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "type-fest": "^3.0.0"
+        "environment": "^1.0.0"
       },
       "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1856,7 +1998,8 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
       "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -1985,6 +2128,7 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -2109,10 +2253,11 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
-      "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -2375,10 +2520,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2586,7 +2732,8 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/env-ci": {
       "version": "11.0.0",
@@ -2742,6 +2889,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -3304,6 +3464,23 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4086,16 +4263,17 @@
       }
     },
     "node_modules/import-from-esm": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.3.tgz",
-      "integrity": "sha512-U3Qt/CyfFpTUv6LOP2jRTLYjphH6zg3okMfHbyqRa/W2w6hr8OsJWVggNlR4jxuojQy81TgTJTxgSkyoteRGMQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-2.0.0.tgz",
+      "integrity": "sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
         "import-meta-resolve": "^4.0.0"
       },
       "engines": {
-        "node": ">=16.20"
+        "node": ">=18.20"
       }
     },
     "node_modules/import-meta-resolve": {
@@ -4931,6 +5109,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.0.tgz",
       "integrity": "sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4939,23 +5118,38 @@
       }
     },
     "node_modules/marked-terminal": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.0.0.tgz",
-      "integrity": "sha512-sNEx8nn9Ktcm6pL0TnRz8tnXq/mSS0Q1FRSwJOAqw4lAB4l49UeDf85Gm1n9RPFm5qurCPjwi1StAQT2XExhZw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^6.2.0",
-        "chalk": "^5.3.0",
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.4.1",
         "cli-highlight": "^2.1.11",
-        "cli-table3": "^0.6.3",
-        "node-emoji": "^2.1.3",
-        "supports-hyperlinks": "^3.0.0"
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.2.0",
+        "supports-hyperlinks": "^3.1.0"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "marked": ">=1 <13"
+        "marked": ">=1 <16"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-regex": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/meow": {
@@ -5096,10 +5290,11 @@
       "dev": true
     },
     "node_modules/node-emoji": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
-      "integrity": "sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.6.0",
         "char-regex": "^1.0.2",
@@ -8386,9 +8581,9 @@
       }
     },
     "node_modules/pretty-ms": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.0.0.tgz",
-      "integrity": "sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
+      "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9005,16 +9200,16 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semantic-release": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.2.0.tgz",
-      "integrity": "sha512-fQfn6e/aYToRtVJYKqneFM1Rg3KP2gh3wSWtpYsLlz6uaPKlISrTzvYAFn+mYWo07F0X1Cz5ucU89AVE8X1mbg==",
+      "version": "24.2.7",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.2.7.tgz",
+      "integrity": "sha512-g7RssbTAbir1k/S7uSwSVZFfFXwpomUB9Oas0+xi9KStSCmeDXcA7rNhiskjLqvUe/Evhx8fVCT16OSa34eM5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
         "@semantic-release/github": "^11.0.0",
-        "@semantic-release/npm": "^12.0.0",
+        "@semantic-release/npm": "^12.0.2",
         "@semantic-release/release-notes-generator": "^14.0.0-beta.1",
         "aggregate-error": "^5.0.0",
         "cosmiconfig": "^9.0.0",
@@ -9027,10 +9222,10 @@
         "git-log-parser": "^1.2.0",
         "hook-std": "^3.0.0",
         "hosted-git-info": "^8.0.0",
-        "import-from-esm": "^1.3.1",
+        "import-from-esm": "^2.0.0",
         "lodash-es": "^4.17.21",
-        "marked": "^12.0.0",
-        "marked-terminal": "^7.0.0",
+        "marked": "^15.0.0",
+        "marked-terminal": "^7.3.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^3.0.0",
         "p-reduce": "^3.0.0",
@@ -9118,24 +9313,24 @@
       }
     },
     "node_modules/semantic-release/node_modules/execa": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.1.tgz",
-      "integrity": "sha512-QY5PPtSonnGwhhHDNI7+3RvY285c7iuJFFB+lU+oEzMY/gEGJ808owqJsrr8Otd1E/x07po1LkUBmdAc5duPAg==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
+      "integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.6",
         "figures": "^6.1.0",
         "get-stream": "^9.0.0",
-        "human-signals": "^8.0.0",
+        "human-signals": "^8.0.1",
         "is-plain-obj": "^4.1.0",
         "is-stream": "^4.0.1",
         "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.0.0",
+        "pretty-ms": "^9.2.0",
         "signal-exit": "^4.1.0",
         "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.0.0"
+        "yoctocolors": "^2.1.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.5.0"
@@ -9162,9 +9357,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/hosted-git-info": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.0.0.tgz",
-      "integrity": "sha512-4nw3vOVR+vHUOT8+U4giwe2tcGv+R3pwwRidUe67DoMBTjhrfr6rZYJVVwdkBE+Um050SG+X9tf0Jo4fOpn01w==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+      "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -9175,9 +9370,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/human-signals": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
-      "integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -9216,6 +9411,19 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/semantic-release/node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/semantic-release/node_modules/npm-run-path": {
       "version": "6.0.0",
@@ -9509,6 +9717,7 @@
       "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
       "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "unicode-emoji-modifier-base": "^1.0.0"
       },
@@ -9734,16 +9943,20 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
-      "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
       },
       "engines": {
         "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -10102,6 +10315,7 @@
       "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
       "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -10343,9 +10557,9 @@
       }
     },
     "node_modules/yoctocolors": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.2.tgz",
-      "integrity": "sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "fs-extra": "11.2.0",
         "inquirer": "9.3.7",
         "lodash": "4.17.21",
-        "npm": "^10.9.3",
         "replace": "1.2.2"
       },
       "bin": {
@@ -35,7 +34,7 @@
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "5.2.1",
         "husky": "9.1.7",
-        "prettier": "3.3.3",
+        "prettier": "3.6.2",
         "pretty-quick": "4.2.2",
         "semantic-release": "24.2.0"
       },
@@ -5184,6 +5183,7 @@
         "which",
         "write-file-atomic"
       ],
+      "dev": true,
       "license": "Artistic-2.0",
       "workspaces": [
         "docs",
@@ -5284,6 +5284,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5300,6 +5301,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5311,11 +5313,13 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5332,6 +5336,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5346,6 +5351,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5357,11 +5363,13 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5377,6 +5385,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "8.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5425,6 +5434,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "9.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5443,6 +5453,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5454,6 +5465,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "6.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5472,6 +5484,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5487,6 +5500,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "4.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5501,6 +5515,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "8.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5516,6 +5531,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
       "version": "20.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5546,6 +5562,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5554,6 +5571,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5562,6 +5580,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "6.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5579,6 +5598,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "8.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5590,6 +5610,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5601,6 +5622,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
       "version": "3.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5609,6 +5631,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "9.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5625,6 +5648,7 @@
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -5634,6 +5658,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5642,6 +5667,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5654,6 +5680,7 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5662,6 +5689,7 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5670,6 +5698,7 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "7.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5678,6 +5707,7 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5686,6 +5716,7 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "6.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5697,21 +5728,25 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5727,6 +5762,7 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5738,6 +5774,7 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5746,6 +5783,7 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "19.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5768,6 +5806,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/chownr": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5776,6 +5815,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -5790,6 +5830,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/tar": {
       "version": "7.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5806,6 +5847,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/yallist": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5814,6 +5856,7 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5825,6 +5868,7 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5833,6 +5877,7 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "4.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5847,6 +5892,7 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "4.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5858,6 +5904,7 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5870,6 +5917,7 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5878,6 +5926,7 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5889,16 +5938,19 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5912,6 +5964,7 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5926,6 +5979,7 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -5937,6 +5991,7 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5953,6 +6008,7 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5961,16 +6017,19 @@
     },
     "node_modules/npm/node_modules/eastasianwidth": {
       "version": "0.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -5980,6 +6039,7 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5988,16 +6048,19 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6006,6 +6069,7 @@
     },
     "node_modules/npm/node_modules/foreground-child": {
       "version": "3.3.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6021,6 +6085,7 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6032,6 +6097,7 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "10.4.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6051,11 +6117,13 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "8.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6067,11 +6135,13 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6084,6 +6154,7 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "7.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6096,6 +6167,7 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -6108,6 +6180,7 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6119,6 +6192,7 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6127,6 +6201,7 @@
     },
     "node_modules/npm/node_modules/ini": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6135,6 +6210,7 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "7.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6152,6 +6228,7 @@
     },
     "node_modules/npm/node_modules/ip-address": {
       "version": "9.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6164,6 +6241,7 @@
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6175,6 +6253,7 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "5.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6186,6 +6265,7 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6194,11 +6274,13 @@
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "3.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6213,11 +6295,13 @@
     },
     "node_modules/npm/node_modules/jsbn": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6226,6 +6310,7 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -6234,6 +6319,7 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
+      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -6242,16 +6328,19 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "9.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6264,6 +6353,7 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "7.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6282,6 +6372,7 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "9.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6302,6 +6393,7 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6313,6 +6405,7 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "11.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6325,6 +6418,7 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6337,6 +6431,7 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "8.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6351,6 +6446,7 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "10.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6369,6 +6465,7 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6380,6 +6477,7 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6392,6 +6490,7 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6407,11 +6506,13 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "10.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "14.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6433,6 +6534,7 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6441,6 +6543,7 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "9.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6455,6 +6558,7 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "7.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6463,6 +6567,7 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6474,6 +6579,7 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6490,6 +6596,7 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6501,6 +6608,7 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6512,6 +6620,7 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6523,6 +6632,7 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6534,6 +6644,7 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6545,6 +6656,7 @@
     },
     "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6556,6 +6668,7 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6567,6 +6680,7 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -6578,11 +6692,13 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6591,6 +6707,7 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "11.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6614,6 +6731,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -6622,6 +6740,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -6636,6 +6755,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
       "version": "7.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6652,6 +6772,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -6660,6 +6781,7 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "8.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6674,6 +6796,7 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6687,6 +6810,7 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6695,6 +6819,7 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6706,6 +6831,7 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "7.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6717,6 +6843,7 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6725,6 +6852,7 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "12.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6739,6 +6867,7 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "9.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6750,6 +6879,7 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "10.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6764,6 +6894,7 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "11.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6776,6 +6907,7 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "18.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6794,6 +6926,7 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -6802,6 +6935,7 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "7.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6813,11 +6947,13 @@
     },
     "node_modules/npm/node_modules/package-json-from-dist": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "19.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6848,6 +6984,7 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6861,6 +6998,7 @@
     },
     "node_modules/npm/node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6869,6 +7007,7 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "1.11.1",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6884,6 +7023,7 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "7.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6896,6 +7036,7 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6904,6 +7045,7 @@
     },
     "node_modules/npm/node_modules/proggy": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6912,6 +7054,7 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -6920,6 +7063,7 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -6928,6 +7072,7 @@
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6940,6 +7085,7 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6951,6 +7097,7 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
+      "dev": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -6958,6 +7105,7 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "4.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6969,6 +7117,7 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6977,6 +7126,7 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6989,6 +7139,7 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6997,12 +7148,14 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.7.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -7014,6 +7167,7 @@
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7025,6 +7179,7 @@
     },
     "node_modules/npm/node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7033,6 +7188,7 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7044,6 +7200,7 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7060,6 +7217,7 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7071,6 +7229,7 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -7079,6 +7238,7 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7095,6 +7255,7 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
       "version": "2.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7108,6 +7269,7 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7117,6 +7279,7 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.8.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7130,6 +7293,7 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "8.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7143,6 +7307,7 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7152,6 +7317,7 @@
     },
     "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7161,11 +7327,13 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7175,16 +7343,19 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.21",
+      "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/sprintf-js": {
       "version": "1.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "12.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7196,6 +7367,7 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7210,6 +7382,7 @@
     "node_modules/npm/node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7223,6 +7396,7 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7235,6 +7409,7 @@
     "node_modules/npm/node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7246,6 +7421,7 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "9.4.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7257,6 +7433,7 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7273,6 +7450,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7284,6 +7462,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7295,6 +7474,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7303,6 +7483,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minizlib": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7315,6 +7496,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7326,16 +7508,19 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
       "version": "0.2.14",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7351,6 +7536,7 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.4.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peerDependencies": {
@@ -7364,6 +7550,7 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7375,6 +7562,7 @@
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7383,6 +7571,7 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7396,6 +7585,7 @@
     },
     "node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7408,6 +7598,7 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7419,6 +7610,7 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7430,11 +7622,13 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7444,6 +7638,7 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7453,6 +7648,7 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7461,11 +7657,13 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/which": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7480,6 +7678,7 @@
     },
     "node_modules/npm/node_modules/which/node_modules/isexe": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -7488,6 +7687,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "8.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7505,6 +7705,7 @@
     "node_modules/npm/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7521,6 +7722,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7535,6 +7737,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7546,11 +7749,13 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7567,6 +7772,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -7581,6 +7787,7 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7593,6 +7800,7 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -8121,9 +8329,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
   "devDependencies": {
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-conventional": "19.8.1",
-    "@semantic-release/commit-analyzer": "13.0.0",
+    "@semantic-release/commit-analyzer": "13.0.1",
     "@semantic-release/git": "10.0.1",
-    "@semantic-release/github": "11.0.0",
-    "@semantic-release/npm": "12.0.1",
-    "@semantic-release/release-notes-generator": "14.0.1",
+    "@semantic-release/github": "11.0.5",
+    "@semantic-release/npm": "12.0.2",
+    "@semantic-release/release-notes-generator": "14.0.3",
     "eslint": "8.57.1",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-prettier": "9.1.0",
@@ -62,7 +62,7 @@
     "husky": "9.1.7",
     "prettier": "3.6.2",
     "pretty-quick": "4.2.2",
-    "semantic-release": "24.2.0"
+    "semantic-release": "24.2.7"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
   },
   "dependencies": {
     "chalk": "5.6.0",
-    "commander": "12.1.0",
+    "commander": "14.0.0",
     "deep-keys": "0.5.0",
     "dotenv": "16.6.1",
     "fs-extra": "11.2.0",
-    "inquirer": "9.3.7",
+    "inquirer": "12.9.4",
     "lodash": "4.17.21",
     "replace": "1.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "chalk": "5.3.0",
+    "chalk": "5.6.0",
     "commander": "12.1.0",
     "deep-keys": "0.5.0",
     "dotenv": "16.6.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chalk": "5.3.0",
     "commander": "12.1.0",
     "deep-keys": "0.5.0",
-    "dotenv": "16.4.5",
+    "dotenv": "16.6.1",
     "fs-extra": "11.2.0",
     "inquirer": "9.3.7",
     "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-prettier": "5.2.1",
     "husky": "9.1.6",
     "prettier": "3.3.3",
-    "pretty-quick": "4.0.0",
+    "pretty-quick": "4.2.2",
     "semantic-release": "24.2.0"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint": "8.57.1",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-prettier": "9.1.0",
-    "eslint-plugin-prettier": "5.2.1",
+    "eslint-plugin-prettier": "5.5.4",
     "husky": "9.1.7",
     "prettier": "3.6.2",
     "pretty-quick": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.2.1",
     "husky": "9.1.7",
-    "prettier": "3.3.3",
+    "prettier": "3.6.2",
     "pretty-quick": "4.2.2",
     "semantic-release": "24.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "replace": "1.2.2"
   },
   "devDependencies": {
-    "@commitlint/cli": "19.5.0",
-    "@commitlint/config-conventional": "19.5.0",
+    "@commitlint/cli": "19.8.1",
+    "@commitlint/config-conventional": "19.8.1",
     "@semantic-release/commit-analyzer": "13.0.0",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.2.1",
-    "husky": "9.1.6",
+    "husky": "9.1.7",
     "prettier": "3.3.3",
     "pretty-quick": "4.2.2",
     "semantic-release": "24.2.0"

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,6 @@ You can also watch an excellent [video](https://www.youtube.com/watch?v=NEvnt3MW
 - [Custom component templates](#custom-component-templates)
 - [Custom component directory](#custom-component-directory)
 - [Custom component files](#custom-component-files)
-- [OpenAi integration (Alpha release)](https://github.com/arminbro/generate-react-cli/tree/alpha?tab=readme-ov-file#openai-integration-alpha-release)
 
 ## You can run it using npx like this:
 

--- a/src/commands/generateComponent.js
+++ b/src/commands/generateComponent.js
@@ -20,16 +20,11 @@ export default function initGenerateComponentCommand(args, cliConfigFile, progra
       'default'
     )
     .option(
-      '-d, --describe <describe>',
-      'Describe the component you want GRC to generate (e.g., Create a counter component that increments by one when I click on the increment button).',
-      null
-    )
-    .option(
       '-f, --flat',
       'Generate the files in the mentioned path instead of creating new folder for it',
       selectedComponentType.flat || false
     )
-    .option('-dr, --dry-run', 'Show what will be generated without writing to disk')
+    .option('--dry-run', 'Show what will be generated without writing to disk')
     .option(
       '--customDirectory <customDirectory>',
       'You can pass a cased path template that will be used as the component path for the component being generated.\n' +


### PR DESCRIPTION
## Summary
  - Removed OpenAI/AI-powered component description features (`--describe` flag)
  - Fixed Commander v14 compatibility by removing invalid short flag format (`-dr` -> `--dry-run` only)
  - Updated dependencies (semantic-release, commitlint, prettier, chalk, eslint-plugin-prettier)

  ## Breaking Changes
  - **REMOVED**: `--describe` flag and AI-powered component generation features
  - **CHANGED**: `-dr` short flag no longer supported, use `--dry-run` instead

  ## Why these changes?
  - Simplified the CLI by removing unused AI integration
  - Fixed compatibility issues with Commander.js v14, which doesn't support multi-character short flags
  - Updated dependencies to the latest versions for security and performance